### PR TITLE
Fixed bugs such as starttls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ integration:
 	cd integration && go test -v
 
 mysql-plugin:
+	go get github.com/go-sql-driver/mysql
 	env GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -buildmode=plugin -o plugin/mysql.so plugin/mysql/main.go
 file-plugin:
 	env GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -buildmode=plugin -o plugin/file.so plugin/file/main.go

--- a/pipe.go
+++ b/pipe.go
@@ -37,13 +37,12 @@ type Data []byte
 type Direction string
 
 const (
-	mailFromPrefix  string = "MAIL FROM:<"
-	rcptToPrefix    string = "RCPT TO:<"
-	mailRegex       string = `[+A-z0-9.-]+@[A-z0-9.-]+`
-	bufferSize      int    = 32 * 1024
-	readyToStartTLS string = "Ready to start TLS"
-	crlf            string = "\r\n"
-	mailHeaderEnd   string = crlf + crlf
+	mailFromPrefix string = "MAIL FROM:<"
+	rcptToPrefix   string = "RCPT TO:<"
+	mailRegex      string = `[+A-z0-9.-=]+@[A-z0-9.-]+`
+	bufferSize     int    = 32 * 1024
+	crlf           string = "\r\n"
+	mailHeaderEnd  string = crlf + crlf
 
 	srcToPxy Direction = ">|"
 	pxyToDst Direction = "|>"
@@ -55,6 +54,10 @@ const (
 
 	upstream Flow = iota
 	downstream
+
+	// SMTP response codes
+	codeServiceReady int = 220
+	//codeActionCompleted int = 250
 )
 
 func (p *Pipe) Do() {

--- a/pipe.go
+++ b/pipe.go
@@ -269,6 +269,10 @@ func (p *Pipe) close() func() {
 	}
 }
 
+func (p *Pipe) isResponseOfReadyToStartTLS(b []byte) bool {
+	return !p.tls && p.locked && bytes.Contains(b, []byte(fmt.Sprint(codeServiceReady)))
+}
+
 func (p *Pipe) removeMailBody(b Data) Data {
 	i := bytes.Index(b, []byte(mailHeaderEnd))
 	if i == -1 {

--- a/pipe.go
+++ b/pipe.go
@@ -272,6 +272,10 @@ func (p *Pipe) close() func() {
 	}
 }
 
+func (p *Pipe) isResponseOfEHLOWithStartTLS(b []byte) bool {
+	return !p.tls && !p.locked && bytes.Contains(b, []byte("STARTTLS"))
+}
+
 func (p *Pipe) isResponseOfReadyToStartTLS(b []byte) bool {
 	return !p.tls && p.locked && bytes.Contains(b, []byte(fmt.Sprint(codeServiceReady)))
 }

--- a/pipe.go
+++ b/pipe.go
@@ -113,6 +113,9 @@ func (p *Pipe) Do() {
 }
 
 func (p *Pipe) pairing(b []byte) {
+	if bytes.Contains(b, []byte("HELO")) {
+		p.sServerName = bytes.TrimSpace(bytes.Replace(b, []byte("HELO"), []byte(""), 1))
+	}
 	if bytes.Contains(b, []byte("EHLO")) {
 		p.sServerName = bytes.TrimSpace(bytes.Replace(b, []byte("EHLO"), []byte(""), 1))
 	}

--- a/pipe.go
+++ b/pipe.go
@@ -83,7 +83,7 @@ func (p *Pipe) Do() {
 			}
 			return b, i
 		})
-		if err != nil {
+		if err != nil && err != net.ErrClosed {
 			go p.afterCommHook([]byte(fmt.Sprintf("io copy error: %s", err.Error())), pxyToDst)
 		}
 		once.Do(p.close())
@@ -104,7 +104,8 @@ func (p *Pipe) Do() {
 			}
 			return b, i
 		})
-		if err != nil {
+		//if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+		if err != nil && err != net.ErrClosed {
 			go p.afterCommHook([]byte(fmt.Sprintf("io copy error: %s", err.Error())), dstToPxy)
 		}
 		once.Do(p.close())

--- a/pipe.go
+++ b/pipe.go
@@ -92,7 +92,7 @@ func (p *Pipe) Do() {
 			if !p.tls && bytes.Contains(b, []byte("STARTTLS")) {
 				go p.afterCommHook(b[0:i], dstToPxy)
 				b, i = p.removeStartTLSCommand(b, i)
-			} else if !p.tls && bytes.Contains(b, []byte(readyToStartTLS)) {
+			} else if p.isResponseOfReadyToStartTLS(b) {
 				go p.afterCommHook(b[0:i], dstToPxy)
 				er := p.connectTLS()
 				if er != nil {
@@ -170,7 +170,7 @@ func (p *Pipe) copy(dr Flow, fn Mediator) (written int64, err error) {
 			if dr == upstream {
 				go p.afterCommHook(p.removeMailBody(buf[0:nr]), srcToDst)
 			} else {
-				if bytes.Contains(buf, []byte(readyToStartTLS)) {
+				if p.isResponseOfReadyToStartTLS(buf) {
 					continue
 				}
 				go p.afterCommHook(buf[0:nr], dstToSrc)

--- a/pipe.go
+++ b/pipe.go
@@ -92,7 +92,7 @@ func (p *Pipe) Do() {
 	// Proxy <--- packet -- Destination
 	go func() {
 		_, err := p.copy(downstream, func(b []byte, i int) ([]byte, int) {
-			if !p.tls && bytes.Contains(b, []byte("STARTTLS")) {
+			if p.isResponseOfEHLOWithStartTLS(b) {
 				go p.afterCommHook(b[0:i], dstToPxy)
 				b, i = p.removeStartTLSCommand(b, i)
 			} else if p.isResponseOfReadyToStartTLS(b) {

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -4,6 +4,16 @@ import (
 	"testing"
 )
 
+func TestIsResponseOfEHLOWithStartTLS(t *testing.T) {
+	pipe := &Pipe{
+		tls:    false,
+		locked: false,
+	}
+	if !pipe.isResponseOfEHLOWithStartTLS([]byte("250-example.test\r\n250-PIPELINING\r\n250-8BITMIME\r\n250-SIZE 41943040\r\n250 STARTTLS\r\n")) {
+		t.Errorf("expected true, but got false")
+	}
+}
+
 func TestIsResponseOfReadyToStartTLS(t *testing.T) {
 	pipe := &Pipe{
 		tls:    false,

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -30,13 +30,6 @@ func TestPairing(t *testing.T) {
 			arg:                  []byte("MAIL FROM:<bob@example.local> SIZE=4095\r\n"),
 			expectSenderServer:   nil,
 			expectSenderAddr:     []byte("bob@example.local"),
-			expectReceiverServer: []byte(""),
-			expectReceiverAddr:   []byte(""),
-		},
-		{
-			arg:                  []byte("MAIL FROM:<SRS0=ZuTb=D3=example.test=alice@example.com> SIZE=4095\r\n"),
-			expectSenderServer:   nil,
-			expectSenderAddr:     []byte("SRS0=ZuTb=D3=example.test=alice@example.com"),
 			expectReceiverServer: nil,
 			expectReceiverAddr:   nil,
 		},
@@ -44,6 +37,22 @@ func TestPairing(t *testing.T) {
 			arg:                  []byte("RCPT TO:<alice@example.com>\r\n"),
 			expectSenderServer:   nil,
 			expectSenderAddr:     nil,
+			expectReceiverServer: []byte("example.com"),
+			expectReceiverAddr:   []byte("alice@example.com"),
+		},
+		{
+			// Sender Rewriting Scheme
+			arg:                  []byte("MAIL FROM:<SRS0=ZuTb=D3=example.test=alice@example.com> SIZE=4095\r\n"),
+			expectSenderServer:   nil,
+			expectSenderAddr:     []byte("SRS0=ZuTb=D3=example.test=alice@example.com"),
+			expectReceiverServer: nil,
+			expectReceiverAddr:   nil,
+		},
+		{
+			// Pipelining
+			arg:                  []byte("MAIL FROM:<bob@example.local> SIZE=4095\r\nRCPT TO:<alice@example.com> ORCPT=rfc822;bob@example.local\r\nDATA\r\n"),
+			expectSenderServer:   nil,
+			expectSenderAddr:     []byte("bob@example.local"),
 			expectReceiverServer: []byte("example.com"),
 			expectReceiverAddr:   []byte("alice@example.com"),
 		},

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -20,6 +20,13 @@ func TestPairing(t *testing.T) {
 			expectReceiverAddr:   nil,
 		},
 		{
+			arg:                  []byte("HELO mx.example.local\r\n"),
+			expectSenderServer:   []byte("mx.example.local"),
+			expectSenderAddr:     nil,
+			expectReceiverServer: nil,
+			expectReceiverAddr:   nil,
+		},
+		{
 			arg:                  []byte("MAIL FROM:<bob@example.local> SIZE=4095\r\n"),
 			expectSenderServer:   nil,
 			expectSenderAddr:     []byte("bob@example.local"),

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -4,6 +4,16 @@ import (
 	"testing"
 )
 
+func TestIsResponseOfReadyToStartTLS(t *testing.T) {
+	pipe := &Pipe{
+		tls:    false,
+		locked: true,
+	}
+	if !pipe.isResponseOfReadyToStartTLS([]byte("220 2.0.0 SMTP server ready\r\n")) {
+		t.Errorf("expected true, but got false")
+	}
+}
+
 func TestRemoveStartTLSCommand(t *testing.T) {
 	var tests = []struct {
 		ehloResp []byte


### PR DESCRIPTION
Fixed some bugs:

- skip starttls command when command list of like a EHLO response after starttls
- use smtp status number and status of starttls requested instead of fixed words("Ready to start TLS")
- support email address format that contains equal for such as Sender rewriting scheme
- do not logging io copy error message if closed connection occured

also add some test cases.