### PR TITLE
Support for specifying outgoing ports in ranges

### DIFF
--- a/cmd/warp/main.go
+++ b/cmd/warp/main.go
@@ -4,6 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/linyows/warp"
 )
@@ -15,7 +18,9 @@ var (
 	builtBy = ""
 	ip      = flag.String("ip", "127.0.0.1", "listen ip")
 	port    = flag.Int("port", 0, "listen port")
+	opr     = flag.String("opr", "", "outbound port range: 12000-12500")
 	verFlag = flag.Bool("version", false, "show build version")
+	oprRe   = regexp.MustCompile(`^([1-9][0-9]{0,5})-([1-9][0-9]{0,5})$`)
 )
 
 func init() {
@@ -27,7 +32,25 @@ func main() {
 		fmt.Fprintf(os.Stderr, buildVersion(version, commit, date, builtBy)+"\n")
 		return
 	}
+
 	w := &warp.Server{Addr: *ip, Port: *port}
+
+	trimedOpr := strings.TrimSpace(*opr)
+	if trimedOpr != "" {
+		matched := oprRe.FindStringSubmatch(trimedOpr)
+		if len(matched) == 3 {
+			s, _ := strconv.Atoi(matched[1])
+			e, _ := strconv.Atoi(matched[2])
+			w.OutboundPorts = &warp.PortRange{
+				Start: s,
+				End:   e,
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "outbound-port-range option format is <number>-<number>\n")
+			return
+		}
+	}
+
 	err := w.Start()
 	if err != nil {
 		panic(err)

--- a/port_range.go
+++ b/port_range.go
@@ -1,0 +1,34 @@
+package warp
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+)
+
+type PortRange struct {
+	start int
+	end   int
+}
+
+func (p *PortRange) TakeOut(host string) (int, error) {
+	timeout := time.Second
+
+	for i := p.start; i <= p.end; i++ {
+		address := net.JoinHostPort(host, strconv.Itoa(i))
+		if ok := isAvailablePort(address, timeout); ok {
+			return i, nil
+		}
+	}
+
+	return 0, fmt.Errorf("not found open port by %d-%d", p.start, p.end)
+}
+
+func isAvailablePort(address string, timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", address, timeout)
+	if conn != nil {
+		defer conn.Close()
+	}
+	return err != nil
+}

--- a/port_range.go
+++ b/port_range.go
@@ -8,21 +8,21 @@ import (
 )
 
 type PortRange struct {
-	start int
-	end   int
+	Start int
+	End   int
 }
 
 func (p *PortRange) TakeOut(host string) (int, error) {
 	timeout := time.Second
 
-	for i := p.start; i <= p.end; i++ {
+	for i := p.Start; i <= p.End; i++ {
 		address := net.JoinHostPort(host, strconv.Itoa(i))
 		if ok := isAvailablePort(address, timeout); ok {
 			return i, nil
 		}
 	}
 
-	return 0, fmt.Errorf("not found open port by %d-%d", p.start, p.end)
+	return 0, fmt.Errorf("not found open port by %d-%d", p.Start, p.End)
 }
 
 func isAvailablePort(address string, timeout time.Duration) bool {

--- a/port_range_test.go
+++ b/port_range_test.go
@@ -43,13 +43,13 @@ func TestTakeOut(t *testing.T) {
 	start := port - 10
 	end := port + 10
 
-	r1 := &PortRange{start: start, end: end}
+	r1 := &PortRange{Start: start, End: end}
 	got1, err := r1.TakeOut(ip)
 	if start != got1 || err != nil {
 		t.Errorf("port range take out expected %d, but got %d", start, got1)
 	}
 
-	r2 := &PortRange{start: port, end: port}
+	r2 := &PortRange{Start: port, End: port}
 	got2, err := r2.TakeOut(ip)
 	if 0 != got2 || err == nil {
 		t.Error("port range take out expected error, but got no error")

--- a/port_range_test.go
+++ b/port_range_test.go
@@ -16,7 +16,7 @@ func listenLocalPort(t *testing.T) (net.Listener, int) {
 		for {
 			conn, _ := ln.Accept()
 			if conn != nil {
-				defer conn.Close()
+				conn.Close()
 			}
 		}
 	}()

--- a/port_range_test.go
+++ b/port_range_test.go
@@ -1,0 +1,57 @@
+package warp
+
+import (
+	"net"
+	"strconv"
+	"testing"
+)
+
+func listenLocalPort(t *testing.T) (net.Listener, int) {
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		for {
+			conn, _ := ln.Accept()
+			if conn != nil {
+				defer conn.Close()
+			}
+		}
+	}()
+
+	_, p, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ln, port
+}
+
+func TestTakeOut(t *testing.T) {
+	ip := "127.0.0.1"
+
+	ln, port := listenLocalPort(t)
+	defer ln.Close()
+
+	start := port - 10
+	end := port + 10
+
+	r1 := &PortRange{start: start, end: end}
+	got1, err := r1.TakeOut(ip)
+	if start != got1 || err != nil {
+		t.Errorf("port range take out expected %d, but got %d", start, got1)
+	}
+
+	r2 := &PortRange{start: port, end: port}
+	got2, err := r2.TakeOut(ip)
+	if 0 != got2 || err == nil {
+		t.Error("port range take out expected error, but got no error")
+	}
+}


### PR DESCRIPTION
This outbound-ip-range option is used in iptables to distinguish between DNAT packets and packets going out of the warp when a host has only one IP address.