### PR TITLE
Performance fixes for Pipe mediators: DATA-phase fast path, allocation reduction, and race elimination

### DIFF
--- a/cmd/warp/main.go
+++ b/cmd/warp/main.go
@@ -3,8 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
+	"net/http"
+	_ "net/http/pprof" // registers /debug/pprof/* on http.DefaultServeMux
 	"os"
 	"strings"
+	"time"
 
 	"github.com/linyows/warp"
 )
@@ -20,6 +24,7 @@ var (
 	plugins = flag.String("plugins", "", "use plugin names: mysql, sqlite, file, slack")
 	maxSize = flag.Int("message-size-limit", 10240000, "The maximal size in bytes of a message")
 	verbose = flag.Bool("verbose", false, "verbose logging")
+	pprofAddr = flag.String("pprof", "", "expose net/http/pprof on host:port (e.g. 127.0.0.1:6060); empty = disabled. Bind to a loopback or otherwise restricted address — pprof endpoints leak heap/goroutine state and are not access-controlled.")
 	verFlag = flag.Bool("version", false, "show build version")
 )
 
@@ -31,6 +36,10 @@ func main() {
 	if *verFlag {
 		fmt.Fprintf(os.Stderr, buildVersion(version, commit, date, builtBy)+"\n")
 		return
+	}
+
+	if *pprofAddr != "" {
+		startPprofServer(*pprofAddr)
 	}
 
 	w := &warp.Server{
@@ -53,6 +62,30 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// startPprofServer launches the net/http/pprof endpoints on addr in a
+// background goroutine. Errors from ListenAndServe are logged but do not
+// abort the warp process — pprof is a diagnostic tool, not a hard
+// dependency of the SMTP proxy.
+func startPprofServer(addr string) {
+	// Conservative timeouts so a stuck pprof client cannot exhaust file
+	// descriptors. The handler itself can stream long captures
+	// (CPU profile with ?seconds=30 etc.) so write timeout is set
+	// generously enough to allow them, while idle/read are kept short.
+	srv := &http.Server{
+		Addr:              addr,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      5 * time.Minute,
+		IdleTimeout:       30 * time.Second,
+	}
+	go func() {
+		log.Printf("pprof endpoints listening on http://%s/debug/pprof/", addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("pprof server error: %s", err)
+		}
+	}()
 }
 
 func buildVersion(version, commit, date, builtBy string) string {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -95,6 +95,27 @@ func (h *testFilterHook) BeforeRelay(data *BeforeRelayData) *FilterResult {
 	return &FilterResult{Action: FilterRelay}
 }
 
+// syncBuffer is a goroutine-safe wrapper around bytes.Buffer for tests
+// that read the buffer's contents (typically for diagnostic Printf) while
+// server goroutines may still be writing to it via the standard log
+// package. Implements io.Writer and fmt.Stringer.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
 // testEnv encapsulates the warp server, test SMTP server, and hook for E2E tests.
 type testEnv struct {
 	ip       string
@@ -103,8 +124,8 @@ type testEnv struct {
 	hostname string
 	hook     *testHook
 	messages chan ReceivedMessage
-	warpLog  bytes.Buffer
-	smtpLog  bytes.Buffer
+	warpLog  syncBuffer
+	smtpLog  syncBuffer
 }
 
 var nextPort int32 = 20000

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,7 +1,6 @@
 package warp
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"strings"
@@ -20,8 +19,8 @@ func TestIntegration(t *testing.T) {
 	hostname := "example.local"
 
 	var (
-		warpLog bytes.Buffer
-		smtpLog bytes.Buffer
+		warpLog syncBuffer
+		smtpLog syncBuffer
 	)
 
 	messages := make(chan ReceivedMessage, 1)

--- a/pipe.go
+++ b/pipe.go
@@ -32,6 +32,12 @@ type Pipe struct {
 	isWaitedStarttlsRes bool
 	isHeaderRemoved     bool
 
+	// ehloResponseHandled latches once the first EHLO response (with or
+	// without STARTTLS) has been classified, so that later downstream
+	// chunks — including mail-body bytes that happen to contain "250" and
+	// "STARTTLS" — cannot retrigger removeStartTLSCommand.
+	ehloResponseHandled bool
+
 	timeAtConnected    time.Time
 	timeAtDataStarting time.Time
 
@@ -315,6 +321,7 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 		go p.afterCommHook(data, dstToPxy)
 		b, i = p.removeStartTLSCommand(b, i)
 		data = b[0:i]
+		p.ehloResponseHandled = true
 	} else if p.isResponseOfReadyToStartTLS(b) {
 		go p.afterCommHook(data, dstToPxy)
 		er := p.connectTLS()
@@ -353,6 +360,7 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 	p.setTimeAtDataStarting(b)
 
 	if p.isResponseOfEHLOWithoutStartTLS(b) {
+		p.ehloResponseHandled = true
 		go p.afterCommHook(data, pxyToSrc)
 	} else {
 		go p.afterCommHook(data, dstToSrc)
@@ -596,11 +604,17 @@ func (p *Pipe) Close() {
 }
 
 func (p *Pipe) isResponseOfEHLOWithStartTLS(b []byte) bool {
-	return !p.tls && !p.locked && bytes.Contains(b, []byte(fmt.Sprint(codeActionCompleted))) && bytes.Contains(b, []byte("STARTTLS"))
+	if p.tls || p.locked || p.ehloResponseHandled {
+		return false
+	}
+	return bytes.Contains(b, []byte(fmt.Sprint(codeActionCompleted))) && bytes.Contains(b, []byte("STARTTLS"))
 }
 
 func (p *Pipe) isResponseOfEHLOWithoutStartTLS(b []byte) bool {
-	return !p.tls && !p.locked && bytes.Contains(b, []byte(fmt.Sprint(codeActionCompleted))) && !bytes.Contains(b, []byte("STARTTLS"))
+	if p.tls || p.locked || p.ehloResponseHandled {
+		return false
+	}
+	return bytes.Contains(b, []byte(fmt.Sprint(codeActionCompleted))) && !bytes.Contains(b, []byte("STARTTLS"))
 }
 
 func (p *Pipe) isResponseOfReadyToStartTLS(b []byte) bool {

--- a/pipe.go
+++ b/pipe.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -25,19 +26,23 @@ type Pipe struct {
 	sServerName []byte
 	rServerName []byte
 
-	tls      bool
-	readytls bool
-	locked   bool
+	// Boolean state flags shared between the upstream and downstream
+	// copy goroutines. They are atomic.Bool so that reads on one side and
+	// writes on the other are race-free under -race (and have well-defined
+	// happens-before semantics under the Go memory model).
+	tls      atomic.Bool
+	readytls atomic.Bool
+	locked   atomic.Bool
 	blocker  chan interface{}
 
-	isWaitedStarttlsRes bool
-	isHeaderRemoved     bool
+	isWaitedStarttlsRes atomic.Bool
+	isHeaderRemoved     atomic.Bool
 
 	// ehloResponseHandled latches once the first EHLO response (with or
 	// without STARTTLS) has been classified, so that later downstream
 	// chunks — including mail-body bytes that happen to contain "250" and
 	// "STARTTLS" — cannot retrigger removeStartTLSCommand.
-	ehloResponseHandled bool
+	ehloResponseHandled atomic.Bool
 
 	timeAtConnected    time.Time
 	timeAtDataStarting time.Time
@@ -45,13 +50,15 @@ type Pipe struct {
 	afterCommHook func(Data, Direction)
 	afterConnHook func()
 
-	// DATA phase buffering for filter hooks
-	inDataPhase        bool
-	dataBuffer         *bytes.Buffer
-	dataBufferSize     int
-	discardingData     bool     // discard remaining client data after buffer overflow
-	pendingRelayMessage []byte  // buffered message waiting for server 354 after filter approval
-	senderIP           string
+	// DATA phase buffering for filter hooks. inDataPhase is shared between
+	// upstream (sets it on DATA command or terminator) and downstream (sets
+	// it on the server's 354 reply); discardingData is upstream-only.
+	inDataPhase         atomic.Bool
+	dataBuffer          *bytes.Buffer
+	dataBufferSize      int
+	discardingData      bool   // discard remaining client data after buffer overflow
+	pendingRelayMessage []byte // buffered message waiting for server 354 after filter approval
+	senderIP            string
 
 	// Filter hook (nil if no FilterHook registered)
 	beforeRelayHook func(*BeforeRelayData) *FilterResult
@@ -202,14 +209,14 @@ func (p *Pipe) mediateOnUpstream(b []byte, i int) ([]byte, int, bool) {
 	// connection, every upstream chunk is mail body bytes — they cannot
 	// contain SMTP commands, so all command/regex scans must be skipped.
 	// Only the end-of-data terminator is checked to exit the phase.
-	if p.inDataPhase && p.beforeRelayHook == nil {
+	if p.inDataPhase.Load() && p.beforeRelayHook == nil {
 		if bytes.Contains(data, dataTerminator) {
-			p.inDataPhase = false
+			p.inDataPhase.Store(false)
 		}
 		return b, i, false
 	}
 
-	if !p.tls || p.rMailAddr == nil {
+	if !p.tls.Load() || p.rMailAddr == nil {
 		p.setSenderMailAddress(data)
 		p.setSenderServerName(data)
 		p.setReceiverMailAddressAndServerName(data)
@@ -217,13 +224,13 @@ func (p *Pipe) mediateOnUpstream(b []byte, i int) ([]byte, int, bool) {
 
 	// FilterHook: DATA phase buffering
 	if p.beforeRelayHook != nil {
-		if p.inDataPhase {
+		if p.inDataPhase.Load() {
 			return p.handleDataPhaseUpstream(b, i)
 		}
 		if p.isDataCommand(data) {
 			// Don't relay DATA to server; send fake 354 to client
 			_, _ = p.sConn.Write([]byte("354 Start mail input" + crlf))
-			p.inDataPhase = true
+			p.inDataPhase.Store(true)
 			p.dataBuffer = &bytes.Buffer{}
 			p.timeAtDataStarting = time.Now()
 			go p.afterCommHook(dupData(data), srcToPxy)
@@ -232,22 +239,22 @@ func (p *Pipe) mediateOnUpstream(b []byte, i int) ([]byte, int, bool) {
 		}
 	}
 
-	if !p.tls && p.readytls {
-		p.locked = true
+	if !p.tls.Load() && p.readytls.Load() {
+		p.locked.Store(true)
 		er := p.starttls()
-		p.isWaitedStarttlsRes = true
+		p.isWaitedStarttlsRes.Store(true)
 		if er != nil {
 			go p.afterCommHook([]byte(fmt.Sprintf("starttls error: %s", er.Error())), pxyToDst)
 		}
-		p.readytls = false
+		p.readytls.Store(false)
 		go p.afterCommHook(dupData(data), srcToPxy)
 	}
 
-	if p.locked {
+	if p.locked.Load() {
 		p.waitForTLSConn(b, i)
 		go p.afterCommHook(dupData(data), pxyToDst)
 	} else {
-		if !p.isHeaderRemoved {
+		if !p.isHeaderRemoved.Load() {
 			go p.afterCommHook(dupData(p.removeMailBody(data)), srcToDst)
 		}
 	}
@@ -274,7 +281,7 @@ func (p *Pipe) handleDataPhaseUpstream(b []byte, i int) ([]byte, int, bool) {
 	// Discard mode: consume remaining client data after buffer overflow until terminator
 	if p.discardingData {
 		if bytes.Contains(data, dataTerminator) {
-			p.inDataPhase = false
+			p.inDataPhase.Store(false)
 			p.discardingData = false
 		}
 		return b, i, true
@@ -289,7 +296,7 @@ func (p *Pipe) handleDataPhaseUpstream(b []byte, i int) ([]byte, int, bool) {
 		go p.afterCommHook([]byte("filter buffer overflow"), onPxy)
 		// Check if terminator is in current chunk
 		if bytes.Contains(data, dataTerminator) {
-			p.inDataPhase = false
+			p.inDataPhase.Store(false)
 			p.discardingData = false
 		}
 		return b, i, true
@@ -325,7 +332,7 @@ func (p *Pipe) handleDataPhaseUpstream(b []byte, i int) ([]byte, int, bool) {
 		result = &FilterResult{Action: FilterRelay}
 	}
 
-	p.inDataPhase = false
+	p.inDataPhase.Store(false)
 	p.dataBuffer = nil
 
 	switch result.Action {
@@ -416,7 +423,7 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 		go p.afterCommHook(dupData(data), dstToPxy)
 		b, i = p.removeStartTLSCommand(data, i)
 		data = b[0:i]
-		p.ehloResponseHandled = true
+		p.ehloResponseHandled.Store(true)
 	} else if p.isResponseOfReadyToStartTLS(data) {
 		go p.afterCommHook(dupData(data), dstToPxy)
 		er := p.connectTLS()
@@ -426,8 +433,8 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 	}
 
 	// remove buffering "220 2.0.0 Ready to start TLS" response
-	if p.isWaitedStarttlsRes {
-		p.isWaitedStarttlsRes = false
+	if p.isWaitedStarttlsRes.Load() {
+		p.isWaitedStarttlsRes.Store(false)
 		return b, i, true
 	}
 
@@ -455,13 +462,13 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 	// time and (b) enter the upstream fast path for non-filter connections.
 	// Scan only the valid data window (data, not b) — the buffer may carry
 	// stale bytes from a previous connection when it comes from the pool.
-	if !p.inDataPhase && p.beforeRelayHook == nil && p.hasResponseCode(data, codeStartingMailInput) {
-		p.inDataPhase = true
+	if !p.inDataPhase.Load() && p.beforeRelayHook == nil && p.hasResponseCode(data, codeStartingMailInput) {
+		p.inDataPhase.Store(true)
 		p.timeAtDataStarting = time.Now()
 	}
 
 	if withoutStartTLS {
-		p.ehloResponseHandled = true
+		p.ehloResponseHandled.Store(true)
 		go p.afterCommHook(dupData(data), pxyToSrc)
 	} else {
 		go p.afterCommHook(dupData(data), dstToSrc)
@@ -610,7 +617,9 @@ func (p *Pipe) copy(dr Flow, fn Mediator) (written int64, err error) {
 		// Only block upstream while pipe is locked for TLS negotiation.
 		// Downstream must continue reading to receive the server's "220 Ready"
 		// response and complete the TLS handshake via connectTLS().
-		if p.locked && dr == upstream {
+		// Reorder so the downstream goroutine never reads p.locked (race-free
+		// short-circuit when dr != upstream).
+		if dr == upstream && p.locked.Load() {
 			continue
 		}
 
@@ -678,7 +687,7 @@ func (p *Pipe) waitForTLSConn(b []byte, i int) {
 	go p.afterCommHook([]byte("pipe locked for tls connection"), onPxy)
 	<-p.blocker
 	go p.afterCommHook([]byte("tls connected, to pipe unlocked"), onPxy)
-	p.locked = false
+	p.locked.Store(false)
 }
 
 func (p *Pipe) connectTLS() error {
@@ -697,7 +706,7 @@ func (p *Pipe) connectTLS() error {
 		return err
 	}
 
-	p.tls = true
+	p.tls.Store(true)
 	p.blocker <- false
 
 	return nil
@@ -720,7 +729,7 @@ func (p *Pipe) Close() {
 // already entered TLS, are locked for handshake, or have already handled
 // the first EHLO response receive (false, false) without scanning.
 func (p *Pipe) classifyEHLOResponse(b []byte) (withStartTLS, withoutStartTLS bool) {
-	if p.tls || p.locked || p.ehloResponseHandled {
+	if p.tls.Load() || p.locked.Load() || p.ehloResponseHandled.Load() {
 		return false, false
 	}
 	if !bytes.Contains(b, codeActionCompletedBytes) {
@@ -743,7 +752,7 @@ func (p *Pipe) isResponseOfEHLOWithoutStartTLS(b []byte) bool {
 }
 
 func (p *Pipe) isResponseOfReadyToStartTLS(b []byte) bool {
-	return !p.tls && p.locked && bytes.Contains(b, codeServiceReadyBytes)
+	return !p.tls.Load() && p.locked.Load() && bytes.Contains(b, codeServiceReadyBytes)
 }
 
 func (p *Pipe) removeMailBody(b Data) Data {
@@ -751,7 +760,7 @@ func (p *Pipe) removeMailBody(b Data) Data {
 	if i == -1 {
 		return b
 	}
-	p.isHeaderRemoved = true
+	p.isHeaderRemoved.Store(true)
 	return b[:i]
 }
 
@@ -763,7 +772,7 @@ func (p *Pipe) removeStartTLSCommand(b []byte, i int) ([]byte, int) {
 		old := []byte(lastLine)
 		b = bytes.Replace(b, old, []byte(""), 1)
 		i = i - len(old)
-		p.readytls = true
+		p.readytls.Store(true)
 
 		arr := strings.Split(string(b), crlf)
 		num := len(arr) - 2
@@ -774,7 +783,7 @@ func (p *Pipe) removeStartTLSCommand(b []byte, i int) ([]byte, int) {
 		old := []byte(intermediateLine)
 		b = bytes.Replace(b, old, []byte(""), 1)
 		i = i - len(old)
-		p.readytls = true
+		p.readytls.Store(true)
 
 	} else {
 		go p.afterCommHook([]byte("starttls replace error"), dstToPxy)

--- a/pipe.go
+++ b/pipe.go
@@ -141,6 +141,17 @@ func isRFCCompliant(match []byte, strictRegex *regexp.Regexp) bool {
 func (p *Pipe) mediateOnUpstream(b []byte, i int) ([]byte, int, bool) {
 	data := b[0:i]
 
+	// Fast path: once the DATA phase has been entered on a non-filter
+	// connection, every upstream chunk is mail body bytes — they cannot
+	// contain SMTP commands, so all command/regex scans must be skipped.
+	// Only the end-of-data terminator is checked to exit the phase.
+	if p.inDataPhase && p.beforeRelayHook == nil {
+		if bytes.Contains(data, dataTerminator) {
+			p.inDataPhase = false
+		}
+		return b, i, false
+	}
+
 	if !p.tls || p.rMailAddr == nil {
 		p.setSenderMailAddress(data)
 		p.setSenderServerName(data)
@@ -356,8 +367,14 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 		// Fall through to relay error response to client
 	}
 
-	// time before email input
-	p.setTimeAtDataStarting(b)
+	// Detect the server's 354 reply once to (a) record the data-phase start
+	// time and (b) enter the upstream fast path for non-filter connections.
+	// hasResponseCode still uses bytes.Split today (fixed in a later patch),
+	// but is gated by !inDataPhase so it runs at most a handful of times.
+	if !p.inDataPhase && p.beforeRelayHook == nil && p.hasResponseCode(b, codeStartingMailInput) {
+		p.inDataPhase = true
+		p.timeAtDataStarting = time.Now()
+	}
 
 	if p.isResponseOfEHLOWithoutStartTLS(b) {
 		p.ehloResponseHandled = true
@@ -367,15 +384,6 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 	}
 
 	return b, i, false
-}
-
-func (p *Pipe) setTimeAtDataStarting(b []byte) {
-	list := bytes.Split(b, []byte(crlf))
-	for _, v := range list {
-		if len(v) >= 3 && string(v[:3]) == fmt.Sprint(codeStartingMailInput) {
-			p.timeAtDataStarting = time.Now()
-		}
-	}
 }
 
 func (p *Pipe) Do() {

--- a/pipe.go
+++ b/pipe.go
@@ -475,7 +475,10 @@ func (p *Pipe) Do() {
 	go p.afterCommHook([]byte(fmt.Sprintf("connected to %s", p.rAddr)), onPxy)
 
 	p.blocker = make(chan interface{})
-	done := make(chan bool)
+	// Buffered so neither copy-goroutine can block on its completion send,
+	// preventing the previously observed goroutine leak when one side
+	// finishes before the other.
+	done := make(chan bool, 2)
 
 	// Sender --- packet --> Proxy
 	go func() {
@@ -495,6 +498,13 @@ func (p *Pipe) Do() {
 		done <- true
 	}()
 
+	// Wait for one side to finish, force-close both connections so the
+	// other side's blocked Read returns with net.ErrClosed, then wait for
+	// it as well. This guarantees both goroutines exit before Do returns,
+	// so their pooled buffers can be released and no goroutines are leaked.
+	<-done
+	_ = p.sConn.Close()
+	_ = p.rConn.Close()
 	<-done
 }
 

--- a/pipe.go
+++ b/pipe.go
@@ -391,14 +391,18 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 
 	// Classify the EHLO response once and reuse below to avoid scanning
 	// the buffer twice (once for "with STARTTLS", once for "without").
-	withStartTLS, withoutStartTLS := p.classifyEHLOResponse(b)
+	// Classifiers MUST scan only the valid data window (data, not b) — the
+	// underlying buffer may extend past i, especially when it is shared
+	// across connections via sync.Pool and still contains bytes from a
+	// previous connection.
+	withStartTLS, withoutStartTLS := p.classifyEHLOResponse(data)
 
 	if withStartTLS {
 		go p.afterCommHook(data, dstToPxy)
-		b, i = p.removeStartTLSCommand(b, i)
+		b, i = p.removeStartTLSCommand(data, i)
 		data = b[0:i]
 		p.ehloResponseHandled = true
-	} else if p.isResponseOfReadyToStartTLS(b) {
+	} else if p.isResponseOfReadyToStartTLS(data) {
 		go p.afterCommHook(data, dstToPxy)
 		er := p.connectTLS()
 		if er != nil {
@@ -434,9 +438,9 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 
 	// Detect the server's 354 reply once to (a) record the data-phase start
 	// time and (b) enter the upstream fast path for non-filter connections.
-	// hasResponseCode still uses bytes.Split today (fixed in a later patch),
-	// but is gated by !inDataPhase so it runs at most a handful of times.
-	if !p.inDataPhase && p.beforeRelayHook == nil && p.hasResponseCode(b, codeStartingMailInput) {
+	// Scan only the valid data window (data, not b) — the buffer may carry
+	// stale bytes from a previous connection when it comes from the pool.
+	if !p.inDataPhase && p.beforeRelayHook == nil && p.hasResponseCode(data, codeStartingMailInput) {
 		p.inDataPhase = true
 		p.timeAtDataStarting = time.Now()
 	}

--- a/pipe.go
+++ b/pipe.go
@@ -66,8 +66,16 @@ type Pipe struct {
 	upDataTail     [dataTerminatorTailLen]byte
 	upDataTailFill int
 
-	pendingRelayMessage []byte // buffered message waiting for server 354 after filter approval
-	senderIP            string
+	// pendingRelayMessage is the message body that the upstream goroutine
+	// has accepted via FilterHook and is waiting to relay to the server
+	// after seeing the server's 354 reply on the downstream side. It is
+	// written by mediateOnUpstream (after the filter decision) and read
+	// by mediateOnDownstream (when 354 arrives), so the handoff crosses
+	// goroutines. atomic.Pointer gives a race-free Store/Load even though
+	// the TCP round-trip would normally serialise the access by accident.
+	pendingRelayMessage atomic.Pointer[[]byte]
+
+	senderIP string
 
 	// Filter hook (nil if no FilterHook registered)
 	beforeRelayHook func(*BeforeRelayData) *FilterResult
@@ -416,13 +424,15 @@ func (p *Pipe) handleDataPhaseUpstream(b []byte, i int) ([]byte, int, bool) {
 
 	case FilterAddHeader:
 		// Store modified message, send DATA to server; downstream handles 354 and relay
-		p.pendingRelayMessage = result.Message
+		m := result.Message
+		p.pendingRelayMessage.Store(&m)
 		_, _ = p.rConn.Write([]byte("DATA" + crlf))
 		go p.afterCommHook([]byte("filter: add header"), onPxy)
 
 	default:
 		// FilterRelay or unknown action: store original message, send DATA to server
-		p.pendingRelayMessage = message
+		m := message
+		p.pendingRelayMessage.Store(&m)
 		_, _ = p.rConn.Write([]byte("DATA" + crlf))
 		go p.afterCommHook([]byte("filter: relay"), onPxy)
 	}
@@ -511,11 +521,11 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 	}
 
 	// FilterHook: relay buffered message to server after receiving 354
-	if p.pendingRelayMessage != nil {
+	if pending := p.pendingRelayMessage.Load(); pending != nil {
 		if p.hasResponseCode(data, codeStartingMailInput) {
 			// Server accepted DATA, relay buffered message + terminator
-			msg := p.pendingRelayMessage
-			p.pendingRelayMessage = nil
+			msg := *pending
+			p.pendingRelayMessage.Store(nil)
 			_, _ = p.rConn.Write(msg)
 			if !bytes.HasSuffix(msg, []byte(crlf)) {
 				_, _ = p.rConn.Write([]byte(crlf))
@@ -525,7 +535,7 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 			return b, i, true // Suppress server's 354 (client already received fake 354)
 		}
 		// Server rejected DATA (e.g. 503, 451): forward error to client
-		p.pendingRelayMessage = nil
+		p.pendingRelayMessage.Store(nil)
 		go p.afterCommHook([]byte("filter: server rejected DATA"), onPxy)
 		// Fall through to relay error response to client
 	}

--- a/pipe.go
+++ b/pipe.go
@@ -302,19 +302,38 @@ func (p *Pipe) handleDataPhaseUpstream(b []byte, i int) ([]byte, int, bool) {
 	return b, i, true
 }
 
-// hasResponseCode checks if any line in b starts with the given 3-digit SMTP response code.
-// Matches "CODE " or "CODE-" (multi-line) at line start per RFC 5321.
+// hasResponseCode checks if any line in b starts with the given 3-digit SMTP
+// response code. Matches "CODE " or "CODE-" (multi-line) at line start per
+// RFC 5321. Implemented as an IndexByte loop so it allocates nothing and
+// only scans the buffer once.
 func (p *Pipe) hasResponseCode(b []byte, code int) bool {
-	codeStr := fmt.Sprint(code)
-	for _, line := range bytes.Split(b, []byte("\n")) {
-		line = bytes.TrimRight(line, "\r")
-		if len(line) < 3 {
+	// Encode code as 3 ASCII digits without going through fmt.Sprint.
+	if code < 100 || code > 999 {
+		return false
+	}
+	d0 := byte('0' + code/100)
+	d1 := byte('0' + (code/10)%10)
+	d2 := byte('0' + code%10)
+
+	for start := 0; start < len(b); {
+		// Locate end of current line.
+		nl := bytes.IndexByte(b[start:], '\n')
+		var line []byte
+		if nl < 0 {
+			line = b[start:]
+			start = len(b)
+		} else {
+			line = b[start : start+nl]
+			start += nl + 1
+		}
+		// Strip a trailing CR if present (without allocating).
+		if len(line) > 0 && line[len(line)-1] == '\r' {
+			line = line[:len(line)-1]
+		}
+		if len(line) < 3 || line[0] != d0 || line[1] != d1 || line[2] != d2 {
 			continue
 		}
-		if string(line[:3]) != codeStr {
-			continue
-		}
-		// Exact 3-char line, or followed by space/hyphen (RFC 5321 reply format)
+		// Exact 3-char line, or followed by space/hyphen (RFC 5321 reply format).
 		if len(line) == 3 || line[3] == ' ' || line[3] == '-' {
 			return true
 		}

--- a/pipe.go
+++ b/pipe.go
@@ -53,10 +53,19 @@ type Pipe struct {
 	// DATA phase buffering for filter hooks. inDataPhase is shared between
 	// upstream (sets it on DATA command or terminator) and downstream (sets
 	// it on the server's 354 reply); discardingData is upstream-only.
-	inDataPhase         atomic.Bool
-	dataBuffer          *bytes.Buffer
-	dataBufferSize      int
-	discardingData      bool   // discard remaining client data after buffer overflow
+	inDataPhase    atomic.Bool
+	dataBuffer     *bytes.Buffer
+	dataBufferSize int
+	discardingData bool // discard remaining client data after buffer overflow
+
+	// Non-filter DATA-phase fast-path state. The end-of-data terminator
+	// "\r\n.\r\n" may straddle a TCP read boundary, so detectDataTerminator
+	// keeps the last (len(dataTerminator)-1) bytes of the previous chunk
+	// here and joins them with the prefix of the next chunk before
+	// scanning. Both fields are upstream-goroutine-only and need no sync.
+	upDataTail     [dataTerminatorTailLen]byte
+	upDataTailFill int
+
 	pendingRelayMessage []byte // buffered message waiting for server 354 after filter approval
 	senderIP            string
 
@@ -208,9 +217,10 @@ func (p *Pipe) mediateOnUpstream(b []byte, i int) ([]byte, int, bool) {
 	// Fast path: once the DATA phase has been entered on a non-filter
 	// connection, every upstream chunk is mail body bytes — they cannot
 	// contain SMTP commands, so all command/regex scans must be skipped.
-	// Only the end-of-data terminator is checked to exit the phase.
+	// detectDataTerminator handles the "\r\n.\r\n" marker even when it
+	// straddles a TCP read boundary by carrying a small tail across calls.
 	if p.inDataPhase.Load() && p.beforeRelayHook == nil {
-		if bytes.Contains(data, dataTerminator) {
+		if p.detectDataTerminator(data) {
 			p.inDataPhase.Store(false)
 		}
 		return b, i, false
@@ -273,6 +283,68 @@ func (p *Pipe) isDataCommand(data []byte) bool {
 
 // dataTerminator is the SMTP end-of-data marker.
 var dataTerminator = []byte("\r\n.\r\n")
+
+// dataTerminatorTailLen is len(dataTerminator)-1: the maximum number of
+// bytes from the previous chunk that we need to keep around in order to
+// detect a terminator that straddles a TCP read boundary.
+const dataTerminatorTailLen = 4
+
+// detectDataTerminator reports whether dataTerminator appears in the
+// current chunk or across the boundary with the previous chunk. It
+// updates p.upDataTail / p.upDataTailFill so the next call can keep
+// scanning across read boundaries.
+//
+// Called only from the upstream goroutine while inDataPhase is true and
+// no FilterHook is registered; the tail fields are accessed by no other
+// goroutine and therefore need no synchronisation.
+func (p *Pipe) detectDataTerminator(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+
+	// First, check the boundary region: prev tail + leading bytes of the
+	// new chunk. A stack-allocated 8-byte buffer fits the worst case
+	// (4 carried bytes + up to 4 new bytes), which is enough to contain
+	// any straddling 5-byte terminator.
+	if p.upDataTailFill > 0 {
+		var boundary [dataTerminatorTailLen * 2]byte
+		n := copy(boundary[:], p.upDataTail[:p.upDataTailFill])
+		take := dataTerminatorTailLen
+		if take > len(data) {
+			take = len(data)
+		}
+		n += copy(boundary[n:], data[:take])
+		if bytes.Contains(boundary[:n], dataTerminator) {
+			p.upDataTailFill = 0
+			return true
+		}
+	}
+
+	// Then check inside the new chunk in one pass.
+	if bytes.Contains(data, dataTerminator) {
+		p.upDataTailFill = 0
+		return true
+	}
+
+	// Save the last dataTerminatorTailLen bytes of the combined stream so
+	// the next call can resume across the next boundary.
+	if len(data) >= dataTerminatorTailLen {
+		copy(p.upDataTail[:], data[len(data)-dataTerminatorTailLen:])
+		p.upDataTailFill = dataTerminatorTailLen
+	} else {
+		keep := dataTerminatorTailLen - len(data)
+		if keep > p.upDataTailFill {
+			keep = p.upDataTailFill
+		}
+		if keep > 0 {
+			// Shift the kept bytes of the existing tail to the front.
+			copy(p.upDataTail[:keep], p.upDataTail[p.upDataTailFill-keep:p.upDataTailFill])
+		}
+		copy(p.upDataTail[keep:], data)
+		p.upDataTailFill = keep + len(data)
+	}
+	return false
+}
 
 // handleDataPhaseUpstream buffers client data during DATA phase and invokes filter hook.
 func (p *Pipe) handleDataPhaseUpstream(b []byte, i int) ([]byte, int, bool) {

--- a/pipe.go
+++ b/pipe.go
@@ -94,6 +94,14 @@ var (
 	mailToRegex         = regexp.MustCompile(rcptToRegex)
 	mailFromRegexStrict = regexp.MustCompile(mailRegexStrict)
 	mailToRegexStrict   = regexp.MustCompile(rcptToRegexStrict)
+
+	// Pre-computed byte slices for SMTP response codes and keywords used in
+	// hot-path classifier scans, so we don't pay an fmt.Sprint allocation
+	// on every chunk.
+	codeActionCompletedBytes   = []byte("250")
+	codeServiceReadyBytes      = []byte("220")
+	codeStartingMailInputBytes = []byte("354")
+	starttlsBytes              = []byte("STARTTLS")
 )
 
 func (e Elapse) String() string {
@@ -328,7 +336,11 @@ func sanitizeReply(reply string) string {
 func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 	data := b[0:i]
 
-	if p.isResponseOfEHLOWithStartTLS(b) {
+	// Classify the EHLO response once and reuse below to avoid scanning
+	// the buffer twice (once for "with STARTTLS", once for "without").
+	withStartTLS, withoutStartTLS := p.classifyEHLOResponse(b)
+
+	if withStartTLS {
 		go p.afterCommHook(data, dstToPxy)
 		b, i = p.removeStartTLSCommand(b, i)
 		data = b[0:i]
@@ -376,7 +388,7 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 		p.timeAtDataStarting = time.Now()
 	}
 
-	if p.isResponseOfEHLOWithoutStartTLS(b) {
+	if withoutStartTLS {
 		p.ehloResponseHandled = true
 		go p.afterCommHook(data, pxyToSrc)
 	} else {
@@ -611,22 +623,36 @@ func (p *Pipe) Close() {
 	go p.afterConnHook()
 }
 
-func (p *Pipe) isResponseOfEHLOWithStartTLS(b []byte) bool {
+// classifyEHLOResponse runs the shared bytes.Contains scans for the EHLO
+// response classifiers exactly once, returning whether the buffer looks
+// like an EHLO reply with or without STARTTLS. Connections that have
+// already entered TLS, are locked for handshake, or have already handled
+// the first EHLO response receive (false, false) without scanning.
+func (p *Pipe) classifyEHLOResponse(b []byte) (withStartTLS, withoutStartTLS bool) {
 	if p.tls || p.locked || p.ehloResponseHandled {
-		return false
+		return false, false
 	}
-	return bytes.Contains(b, []byte(fmt.Sprint(codeActionCompleted))) && bytes.Contains(b, []byte("STARTTLS"))
+	if !bytes.Contains(b, codeActionCompletedBytes) {
+		return false, false
+	}
+	if bytes.Contains(b, starttlsBytes) {
+		return true, false
+	}
+	return false, true
+}
+
+func (p *Pipe) isResponseOfEHLOWithStartTLS(b []byte) bool {
+	withStartTLS, _ := p.classifyEHLOResponse(b)
+	return withStartTLS
 }
 
 func (p *Pipe) isResponseOfEHLOWithoutStartTLS(b []byte) bool {
-	if p.tls || p.locked || p.ehloResponseHandled {
-		return false
-	}
-	return bytes.Contains(b, []byte(fmt.Sprint(codeActionCompleted))) && !bytes.Contains(b, []byte("STARTTLS"))
+	_, withoutStartTLS := p.classifyEHLOResponse(b)
+	return withoutStartTLS
 }
 
 func (p *Pipe) isResponseOfReadyToStartTLS(b []byte) bool {
-	return !p.tls && p.locked && bytes.Contains(b, []byte(fmt.Sprint(codeServiceReady)))
+	return !p.tls && p.locked && bytes.Contains(b, codeServiceReadyBytes)
 }
 
 func (p *Pipe) removeMailBody(b Data) Data {

--- a/pipe.go
+++ b/pipe.go
@@ -138,6 +138,21 @@ func releaseCopyBuf(bp *[]byte) {
 	copyBufPool.Put(bp)
 }
 
+// dupData returns an independent copy of b. afterCommHook is invoked
+// asynchronously via `go p.afterCommHook(...)`; its byte-slice arguments
+// must not alias the per-direction read buffer, because Pipe.copy reuses
+// that buffer on every iteration (and the buffer itself is now shared
+// across connections via sync.Pool). Without this defensive copy the
+// async hook can read the same array that the next Read is writing into.
+func dupData(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+	c := make([]byte, len(b))
+	copy(c, b)
+	return c
+}
+
 func (e Elapse) String() string {
 	return fmt.Sprintf("%d msec", e)
 }
@@ -211,7 +226,7 @@ func (p *Pipe) mediateOnUpstream(b []byte, i int) ([]byte, int, bool) {
 			p.inDataPhase = true
 			p.dataBuffer = &bytes.Buffer{}
 			p.timeAtDataStarting = time.Now()
-			go p.afterCommHook(data, srcToPxy)
+			go p.afterCommHook(dupData(data), srcToPxy)
 			go p.afterCommHook([]byte("354 Start mail input"), pxyToSrc)
 			return b, i, true // Suppress relay to server
 		}
@@ -225,15 +240,15 @@ func (p *Pipe) mediateOnUpstream(b []byte, i int) ([]byte, int, bool) {
 			go p.afterCommHook([]byte(fmt.Sprintf("starttls error: %s", er.Error())), pxyToDst)
 		}
 		p.readytls = false
-		go p.afterCommHook(data, srcToPxy)
+		go p.afterCommHook(dupData(data), srcToPxy)
 	}
 
 	if p.locked {
 		p.waitForTLSConn(b, i)
-		go p.afterCommHook(data, pxyToDst)
+		go p.afterCommHook(dupData(data), pxyToDst)
 	} else {
 		if !p.isHeaderRemoved {
-			go p.afterCommHook(p.removeMailBody(data), srcToDst)
+			go p.afterCommHook(dupData(p.removeMailBody(data)), srcToDst)
 		}
 	}
 
@@ -398,12 +413,12 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 	withStartTLS, withoutStartTLS := p.classifyEHLOResponse(data)
 
 	if withStartTLS {
-		go p.afterCommHook(data, dstToPxy)
+		go p.afterCommHook(dupData(data), dstToPxy)
 		b, i = p.removeStartTLSCommand(data, i)
 		data = b[0:i]
 		p.ehloResponseHandled = true
 	} else if p.isResponseOfReadyToStartTLS(data) {
-		go p.afterCommHook(data, dstToPxy)
+		go p.afterCommHook(dupData(data), dstToPxy)
 		er := p.connectTLS()
 		if er != nil {
 			go p.afterCommHook([]byte(fmt.Sprintf("TLS connection error: %s", er.Error())), dstToPxy)
@@ -447,9 +462,9 @@ func (p *Pipe) mediateOnDownstream(b []byte, i int) ([]byte, int, bool) {
 
 	if withoutStartTLS {
 		p.ehloResponseHandled = true
-		go p.afterCommHook(data, pxyToSrc)
+		go p.afterCommHook(dupData(data), pxyToSrc)
 	} else {
-		go p.afterCommHook(data, dstToSrc)
+		go p.afterCommHook(dupData(data), dstToSrc)
 	}
 
 	return b, i, false

--- a/pipe.go
+++ b/pipe.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -102,7 +103,40 @@ var (
 	codeServiceReadyBytes      = []byte("220")
 	codeStartingMailInputBytes = []byte("354")
 	starttlsBytes              = []byte("STARTTLS")
+
+	// copyBufPool recycles the per-direction read buffer used by Pipe.copy.
+	// Each connection previously made(`[]byte, p.bufferSize`) twice
+	// (upstream + downstream); with a default bufferSize of 10 MiB that is
+	// 20 MiB of fresh allocation per connection, which dominates the
+	// allocation profile under load.
+	copyBufPool sync.Pool
 )
+
+// acquireCopyBuf returns a *[]byte from the pool with len == size. If the
+// pool is empty or the pooled entry is too small, a fresh slice is created.
+func acquireCopyBuf(size int) *[]byte {
+	if v := copyBufPool.Get(); v != nil {
+		bp := v.(*[]byte)
+		if cap(*bp) >= size {
+			*bp = (*bp)[:size]
+			return bp
+		}
+		// Pooled buffer was smaller than requested; drop it (let GC) and
+		// allocate a fresh one. The replacement will be pooled on release.
+	}
+	nb := make([]byte, size)
+	return &nb
+}
+
+// releaseCopyBuf returns a buffer to the pool, restoring its slice header
+// to its full capacity so the next caller can resize freely.
+func releaseCopyBuf(bp *[]byte) {
+	if bp == nil {
+		return
+	}
+	*bp = (*bp)[:cap(*bp)]
+	copyBufPool.Put(bp)
+}
 
 func (e Elapse) String() string {
 	return fmt.Sprintf("%d msec", e)
@@ -532,7 +566,15 @@ func (p *Pipe) copy(dr Flow, fn Mediator) (written int64, err error) {
 		}
 		go p.afterCommHook([]byte(fmt.Sprintf("io.Reader size: %d", size)), onPxy)
 	}
-	buf := make([]byte, p.bufferSize)
+
+	// Acquire the per-direction read buffer from a sync.Pool so it can be
+	// reused across connections. origBuf retains the underlying array; the
+	// per-iteration buf is reset to origBuf before each Read so that a
+	// mediator returning a smaller/different slice (e.g. removeStartTLSCommand
+	// via bytes.Replace) does not shrink the buffer used by the next Read.
+	bufp := acquireCopyBuf(size)
+	defer releaseCopyBuf(bufp)
+	origBuf := *bufp
 
 	for {
 		var isContinue bool
@@ -543,6 +585,7 @@ func (p *Pipe) copy(dr Flow, fn Mediator) (written int64, err error) {
 			continue
 		}
 
+		buf := origBuf
 		nr, er := p.src(dr).Read(buf)
 		if nr > 0 {
 			// Run the Mediator!

--- a/pipe.go
+++ b/pipe.go
@@ -105,11 +105,11 @@ var (
 
 	// Pre-computed byte slices for SMTP response codes and keywords used in
 	// hot-path classifier scans, so we don't pay an fmt.Sprint allocation
-	// on every chunk.
-	codeActionCompletedBytes   = []byte("250")
-	codeServiceReadyBytes      = []byte("220")
-	codeStartingMailInputBytes = []byte("354")
-	starttlsBytes              = []byte("STARTTLS")
+	// on every chunk. (codeStartingMailInput "354" is handled via the digit
+	// math inside hasResponseCode and intentionally has no []byte form.)
+	codeActionCompletedBytes = []byte("250")
+	codeServiceReadyBytes    = []byte("220")
+	starttlsBytes            = []byte("STARTTLS")
 
 	// copyBufPool recycles the per-direction read buffer used by Pipe.copy.
 	// Each connection previously made(`[]byte, p.bufferSize`) twice

--- a/pipe_perf_test.go
+++ b/pipe_perf_test.go
@@ -263,3 +263,75 @@ func TestMediateOnDownstream_RemoveStartTLSNoMisfireAfterEHLO(t *testing.T) {
 		t.Fatalf("expected p.readytls=false after mail-body chunk; got true (misfire regression)")
 	}
 }
+
+// TestDetectDataTerminator_SplitAcrossChunks verifies that the upstream
+// fast-path terminator detector finds "\r\n.\r\n" even when it straddles
+// a TCP read boundary. Without the tail carry-over, a chunk pair like
+// ("...body\r\n.", "\r\n") would leave inDataPhase=true forever and
+// cause subsequent SMTP commands to be relayed as body bytes.
+func TestDetectDataTerminator_SplitAcrossChunks(t *testing.T) {
+	tests := []struct {
+		name   string
+		chunks [][]byte
+	}{
+		{
+			name:   "single chunk",
+			chunks: [][]byte{[]byte("body bytes\r\n.\r\n")},
+		},
+		{
+			name:   "split after first CR",
+			chunks: [][]byte{[]byte("body bytes\r"), []byte("\n.\r\n")},
+		},
+		{
+			name:   "split after first LF",
+			chunks: [][]byte{[]byte("body bytes\r\n"), []byte(".\r\n")},
+		},
+		{
+			name:   "split after dot",
+			chunks: [][]byte{[]byte("body bytes\r\n."), []byte("\r\n")},
+		},
+		{
+			name:   "split after trailing CR",
+			chunks: [][]byte{[]byte("body bytes\r\n.\r"), []byte("\n")},
+		},
+		{
+			name:   "each byte of terminator in its own chunk",
+			chunks: [][]byte{[]byte("body bytes"), []byte("\r"), []byte("\n"), []byte("."), []byte("\r"), []byte("\n")},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newPerfPipe()
+			var found bool
+			for _, ch := range tc.chunks {
+				if p.detectDataTerminator(ch) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("terminator not detected across chunks %v", tc.chunks)
+			}
+		})
+	}
+}
+
+// TestDetectDataTerminator_NoFalsePositive ensures the detector does not
+// trip on body bytes that merely contain individual terminator characters
+// without forming the full "\r\n.\r\n" sequence.
+func TestDetectDataTerminator_NoFalsePositive(t *testing.T) {
+	p := newPerfPipe()
+	// Body containing dots, CRLFs, and ".." (dot-stuffed) lines but never
+	// the literal "\r\n.\r\n" terminator.
+	chunks := [][]byte{
+		[]byte("Line one with a period.\r\n"),
+		[]byte("..dot-stuffed leading dot\r\n"),
+		[]byte("more body\r\n"),
+	}
+	for _, ch := range chunks {
+		if p.detectDataTerminator(ch) {
+			t.Fatalf("false positive on chunk %q", ch)
+		}
+	}
+}

--- a/pipe_perf_test.go
+++ b/pipe_perf_test.go
@@ -101,7 +101,7 @@ func BenchmarkMediateOnDownstream_LargeBuffer(b *testing.B) {
 	const size = 1024 * 1024
 	chunk := buildMailBodyChunk(size)
 	p := newPerfPipe()
-	p.tls = true
+	p.tls.Store(true)
 	buf := make([]byte, 0, len(chunk))
 	b.SetBytes(int64(len(chunk)))
 	b.ReportAllocs()
@@ -160,7 +160,7 @@ func BenchmarkMediateOnUpstream_InDataPhase(b *testing.B) {
 	const size = 1024 * 1024
 	chunk := buildMailBodyChunk(size)
 	p := newPerfPipe()
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	buf := make([]byte, 0, len(chunk))
 	b.SetBytes(int64(len(chunk)))
 	b.ReportAllocs()
@@ -194,7 +194,7 @@ func BenchmarkMediateOnUpstream_DataBody_NoRcptSet(b *testing.B) {
 func BenchmarkMediateOnDownstream_EHLOResponse(b *testing.B) {
 	chunk := buildEHLOResponseChunk()
 	p := newPerfPipe()
-	p.tls = true // suppress STARTTLS path; we want the scan cost only
+	p.tls.Store(true) // suppress STARTTLS path; we want the scan cost only
 	buf := make([]byte, 0, len(chunk))
 	b.SetBytes(int64(len(chunk)))
 	b.ReportAllocs()
@@ -231,10 +231,10 @@ func TestMediateOnDownstream_RemoveStartTLSNoMisfireAfterEHLO(t *testing.T) {
 	ehloBuf := make([]byte, len(ehlo))
 	copy(ehloBuf, ehlo)
 	_, _, _ = p.mediateOnDownstream(ehloBuf, len(ehloBuf))
-	if !p.readytls {
+	if !p.readytls.Load() {
 		t.Fatalf("expected p.readytls=true after handling a real EHLO STARTTLS response, got false")
 	}
-	if !p.ehloResponseHandled {
+	if !p.ehloResponseHandled.Load() {
 		t.Fatalf("expected ehloResponseHandled=true after first EHLO response, got false")
 	}
 
@@ -254,12 +254,12 @@ func TestMediateOnDownstream_RemoveStartTLSNoMisfireAfterEHLO(t *testing.T) {
 	}
 
 	// Reset p.readytls so we can assert mediateOnDownstream does NOT set it.
-	p.readytls = false
+	p.readytls.Store(false)
 	bodyBuf := make([]byte, len(body))
 	copy(bodyBuf, body)
 	_, _, _ = p.mediateOnDownstream(bodyBuf, len(bodyBuf))
 
-	if p.readytls {
+	if p.readytls.Load() {
 		t.Fatalf("expected p.readytls=false after mail-body chunk; got true (misfire regression)")
 	}
 }

--- a/pipe_perf_test.go
+++ b/pipe_perf_test.go
@@ -57,12 +57,22 @@ func buildMailBodyChunk(size int) []byte {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Layer A: Function-level benchmarks for the hot paths called out in
-// PERFORMANCE_INVESTIGATION.md (bytes.Split / bytes.Contains / Replace).
+// Layer A: Function-level benchmarks for the per-chunk hot paths in
+// Pipe.mediateOnUpstream / mediateOnDownstream. CPU and allocation
+// profiles taken under sustained mail-burst load showed three offenders:
 //
-// Each benchmark records B/op and allocs/op via b.ReportAllocs so that the
-// effect of upcoming fixes can be measured numerically. b.SetBytes is set to
-// the input chunk size so `MB/s` throughput is also reported.
+//   1. bytes.Split inside setTimeAtDataStarting / hasResponseCode —
+//      builds [][]byte and TrimRight-s each segment, on every chunk.
+//   2. bytes.Contains scans across the full read buffer in the EHLO
+//      response classifiers, even after the first EHLO response has
+//      already been handled.
+//   3. bytes.Replace inside removeStartTLSCommand allocating a fresh
+//      copy of the full chunk when a mail body happens to contain
+//      "250-STARTTLS\r\n" or "250 STARTTLS\r\n".
+//
+// Each benchmark records B/op and allocs/op via b.ReportAllocs so the
+// effect of the fixes is measurable. b.SetBytes is set to the input
+// chunk size so `MB/s` throughput is also reported.
 // ─────────────────────────────────────────────────────────────────────
 
 // BenchmarkHasResponseCode_LargeBuffer measures bytes.Split inside
@@ -113,12 +123,17 @@ func BenchmarkMediateOnDownstream_LargeBuffer(b *testing.B) {
 }
 
 // BenchmarkMediateOnDownstream_LargeBuffer_WithMisfire enables the
-// removeStartTLSCommand misfire path (p.tls=false) so the per-iteration cost
-// includes bytes.Replace allocations over the full buffer when the chunk
-// happens to contain the literal "250-STARTTLS\r\n" sequence.
+// removeStartTLSCommand misfire path (p.tls=false) so the per-iteration
+// cost includes bytes.Replace allocations over the full buffer when the
+// chunk happens to contain the literal "250-STARTTLS\r\n" sequence.
 //
-// This benchmark numerically captures the cost of PERFORMANCE_INVESTIGATION.md
-// "発見 A" (1.5 GB bytes.Replace alloc traffic in production).
+// This benchmark numerically captures the cost of the misfire pattern
+// observed in production: the EHLO-response classifier returned true on
+// mail-body chunks that incidentally contained both "250" (e.g. in a
+// Received-header IP fragment) and "STARTTLS" (as a literal word), and
+// removeStartTLSCommand then copied the entire chunk via bytes.Replace.
+// Allocation profile from one production sample attributed ~1.5 GB of
+// total allocation to this single bytes.Replace call site.
 func BenchmarkMediateOnDownstream_LargeBuffer_WithMisfire(b *testing.B) {
 	const size = 1024 * 1024
 	chunk := buildMailBodyChunk(size)
@@ -209,12 +224,23 @@ func BenchmarkMediateOnDownstream_EHLOResponse(b *testing.B) {
 // Layer B: Regression test documenting the removeStartTLSCommand misfire.
 // ─────────────────────────────────────────────────────────────────────
 
-// TestMediateOnDownstream_RemoveStartTLSNoMisfireAfterEHLO verifies the fix
-// for PERFORMANCE_INVESTIGATION.md "発見 A": once the first EHLO response
-// has been handled, downstream chunks that happen to contain "250" and
-// "STARTTLS" — e.g. a mail body where "250-STARTTLS\r\n" appears in
-// documentation text — must NOT retrigger removeStartTLSCommand, must NOT
-// allocate a full-buffer bytes.Replace copy, and must NOT flip p.readytls.
+// TestMediateOnDownstream_RemoveStartTLSNoMisfireAfterEHLO verifies the
+// once-only latch on the EHLO-response classifier.
+//
+// Background: removeStartTLSCommand exists to strip "250-STARTTLS\r\n"
+// from the EHLO reply so the client never tries to upgrade. Without a
+// latch the classifier fires on any downstream chunk that contains both
+// "250" and "STARTTLS", including a mail body that incidentally has the
+// literal "250-STARTTLS\r\n" sequence (documentation text, captured
+// EHLO traces, log excerpts, etc.). Each misfire allocates a full-chunk
+// bytes.Replace copy and flips p.readytls, which corrupts the
+// STARTTLS state machine.
+//
+// After the ehloResponseHandled latch lands, once the real EHLO reply
+// has been processed any subsequent downstream chunk — even one that
+// looks like an EHLO reply — must NOT retrigger removeStartTLSCommand,
+// must NOT allocate a full-buffer bytes.Replace copy, and must NOT
+// flip p.readytls.
 func TestMediateOnDownstream_RemoveStartTLSNoMisfireAfterEHLO(t *testing.T) {
 	p := &Pipe{
 		afterCommHook: func(b Data, to Direction) {},

--- a/pipe_perf_test.go
+++ b/pipe_perf_test.go
@@ -1,0 +1,244 @@
+package warp
+
+import (
+	"bytes"
+	"testing"
+)
+
+// newPerfPipe constructs a Pipe with a no-op afterCommHook and minimal state
+// so that mediator functions can be called in isolation by benchmarks/tests.
+func newPerfPipe() *Pipe {
+	return &Pipe{
+		bufferSize:    10 * 1024 * 1024,
+		afterCommHook: func(b Data, to Direction) {},
+		afterConnHook: func() {},
+	}
+}
+
+// buildEHLOResponseChunk returns a typical EHLO response advertising STARTTLS.
+func buildEHLOResponseChunk() []byte {
+	return []byte(
+		"250-mail.example.com\r\n" +
+			"250-PIPELINING\r\n" +
+			"250-SIZE 10240000\r\n" +
+			"250-STARTTLS\r\n" +
+			"250 8BITMIME\r\n",
+	)
+}
+
+// buildMailBodyChunk returns a synthetic mail body chunk of the given size.
+// It deliberately embeds substrings that mimic real-world false positives for
+// the SMTP-response classifiers:
+//   - "250" (in a Received header)
+//   - "STARTTLS" (as a literal word in documentation-like body text)
+//   - the exact sequence "250-STARTTLS\r\n" that the misfired
+//     removeStartTLSCommand attempts to bytes.Replace
+//
+// The result is padded with non-matching text up to size bytes.
+func buildMailBodyChunk(size int) []byte {
+	header := "Received: from sender.example (sender.example [192.0.2.250])\r\n" +
+		"\tby mx.example.com with ESMTP id 250abc; deployment notes\r\n" +
+		"From: alice@example.test\r\n" +
+		"To: bob@example.local\r\n" +
+		"Subject: Notes on TLS deployment\r\n" +
+		"\r\n" +
+		"Our migration plan mentions 250-STARTTLS\r\n" +
+		"as an EHLO continuation marker.\r\n"
+	var buf bytes.Buffer
+	buf.WriteString(header)
+	for buf.Len() < size {
+		buf.WriteString("Lorem ipsum dolor sit amet. ")
+	}
+	body := buf.Bytes()
+	if len(body) > size {
+		body = body[:size]
+	}
+	return body
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Layer A: Function-level benchmarks for the hot paths called out in
+// PERFORMANCE_INVESTIGATION.md (bytes.Split / bytes.Contains / Replace).
+//
+// Each benchmark records B/op and allocs/op via b.ReportAllocs so that the
+// effect of upcoming fixes can be measured numerically. b.SetBytes is set to
+// the input chunk size so `MB/s` throughput is also reported.
+// ─────────────────────────────────────────────────────────────────────
+
+// BenchmarkSetTimeAtDataStarting_LargeBuffer measures the cost of the
+// bytes.Split + [][]byte allocation that runs on EVERY downstream chunk,
+// including chunks that can never contain a 354 response code.
+func BenchmarkSetTimeAtDataStarting_LargeBuffer(b *testing.B) {
+	const size = 1024 * 1024
+	chunk := buildMailBodyChunk(size)
+	p := newPerfPipe()
+	b.SetBytes(int64(len(chunk)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.setTimeAtDataStarting(chunk)
+	}
+}
+
+// BenchmarkHasResponseCode_LargeBuffer measures bytes.Split inside
+// hasResponseCode against a large buffer.
+func BenchmarkHasResponseCode_LargeBuffer(b *testing.B) {
+	const size = 1024 * 1024
+	chunk := buildMailBodyChunk(size)
+	p := newPerfPipe()
+	b.SetBytes(int64(len(chunk)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.hasResponseCode(chunk, codeStartingMailInput)
+	}
+}
+
+// BenchmarkIsResponseOfEHLOWithStartTLS_MailBody shows the cost of the two
+// bytes.Contains scans over a large buffer.
+func BenchmarkIsResponseOfEHLOWithStartTLS_MailBody(b *testing.B) {
+	const size = 1024 * 1024
+	chunk := buildMailBodyChunk(size)
+	p := newPerfPipe()
+	b.SetBytes(int64(len(chunk)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.isResponseOfEHLOWithStartTLS(chunk)
+	}
+}
+
+// BenchmarkMediateOnDownstream_LargeBuffer measures the per-chunk cost of
+// mediateOnDownstream on a 1 MiB chunk. p.tls is forced to true so that the
+// removeStartTLSCommand path is suppressed; this isolates the scan-only cost
+// of the always-on classifiers and setTimeAtDataStarting.
+func BenchmarkMediateOnDownstream_LargeBuffer(b *testing.B) {
+	const size = 1024 * 1024
+	chunk := buildMailBodyChunk(size)
+	p := newPerfPipe()
+	p.tls = true
+	buf := make([]byte, 0, len(chunk))
+	b.SetBytes(int64(len(chunk)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf = append(buf[:0], chunk...)
+		_, _, _ = p.mediateOnDownstream(buf, len(buf))
+	}
+}
+
+// BenchmarkMediateOnDownstream_LargeBuffer_WithMisfire enables the
+// removeStartTLSCommand misfire path (p.tls=false) so the per-iteration cost
+// includes bytes.Replace allocations over the full buffer when the chunk
+// happens to contain the literal "250-STARTTLS\r\n" sequence.
+//
+// This benchmark numerically captures the cost of PERFORMANCE_INVESTIGATION.md
+// "発見 A" (1.5 GB bytes.Replace alloc traffic in production).
+func BenchmarkMediateOnDownstream_LargeBuffer_WithMisfire(b *testing.B) {
+	const size = 1024 * 1024
+	chunk := buildMailBodyChunk(size)
+	p := newPerfPipe()
+	buf := make([]byte, 0, len(chunk))
+	b.SetBytes(int64(len(chunk)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf = append(buf[:0], chunk...)
+		_, _, _ = p.mediateOnDownstream(buf, len(buf))
+	}
+}
+
+// BenchmarkMediateOnUpstream_DataBody_PlainSMTP measures upstream mediation
+// when the receiver mail address is already known (RCPT TO already processed):
+// the regex-based extraction is skipped per the existing guard.
+func BenchmarkMediateOnUpstream_DataBody_PlainSMTP(b *testing.B) {
+	const size = 1024 * 1024
+	chunk := buildMailBodyChunk(size)
+	p := newPerfPipe()
+	p.rMailAddr = []byte("bob@example.local")
+	buf := make([]byte, 0, len(chunk))
+	b.SetBytes(int64(len(chunk)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf = append(buf[:0], chunk...)
+		_, _, _ = p.mediateOnUpstream(buf, len(buf))
+	}
+}
+
+// BenchmarkMediateOnUpstream_DataBody_NoRcptSet measures upstream mediation
+// when rMailAddr has not been set yet: every chunk runs the regex-based
+// sender/receiver extraction over the full buffer.
+func BenchmarkMediateOnUpstream_DataBody_NoRcptSet(b *testing.B) {
+	const size = 1024 * 1024
+	chunk := buildMailBodyChunk(size)
+	p := newPerfPipe()
+	buf := make([]byte, 0, len(chunk))
+	b.SetBytes(int64(len(chunk)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf = append(buf[:0], chunk...)
+		_, _, _ = p.mediateOnUpstream(buf, len(buf))
+	}
+}
+
+// BenchmarkMediateOnDownstream_EHLOResponse is a baseline for comparison:
+// a real EHLO response is small (~100 B), so the per-chunk scan cost should
+// be negligible compared to the large-buffer benchmarks above.
+func BenchmarkMediateOnDownstream_EHLOResponse(b *testing.B) {
+	chunk := buildEHLOResponseChunk()
+	p := newPerfPipe()
+	p.tls = true // suppress STARTTLS path; we want the scan cost only
+	buf := make([]byte, 0, len(chunk))
+	b.SetBytes(int64(len(chunk)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf = append(buf[:0], chunk...)
+		_, _, _ = p.mediateOnDownstream(buf, len(buf))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Layer B: Regression test documenting the removeStartTLSCommand misfire.
+// ─────────────────────────────────────────────────────────────────────
+
+// TestMediateOnDownstream_RemoveStartTLSMisfire reproduces the bug described
+// in PERFORMANCE_INVESTIGATION.md "発見 A": when a downstream chunk happens
+// to contain both "250" and "STARTTLS" (here, the literal sequence
+// "250-STARTTLS\r\n" embedded in a relayed mail body), the classifier
+// returns true, removeStartTLSCommand runs bytes.Replace over the chunk,
+// and p.readytls is wrongly flipped to true.
+//
+// This test asserts the CURRENT (buggy) behavior so the misfire is locked in
+// as a regression. After the fix lands (e.g. an ehloResponseHandled latch on
+// the Pipe), this test should be updated to assert that p.readytls remains
+// false and that removeStartTLSCommand is NOT invoked.
+func TestMediateOnDownstream_RemoveStartTLSMisfire(t *testing.T) {
+	body := []byte("From: alice@example.test\r\n" +
+		"To: bob@example.local\r\n" +
+		"Subject: TLS notes\r\n" +
+		"\r\n" +
+		"Our EHLO continuation looks like 250-STARTTLS\r\n" +
+		"...and that is the issue.\r\n")
+
+	p := &Pipe{
+		afterCommHook: func(b Data, to Direction) {},
+		afterConnHook: func() {},
+	}
+
+	if !p.isResponseOfEHLOWithStartTLS(body) {
+		t.Fatalf("precondition: classifier should misfire on the mail-body chunk, got false")
+	}
+
+	buf := make([]byte, len(body))
+	copy(buf, body)
+	_, _, _ = p.mediateOnDownstream(buf, len(buf))
+
+	if !p.readytls {
+		t.Fatalf("expected p.readytls=true after the misfired removeStartTLSCommand; got false. " +
+			"If this trips, the misfire was likely fixed upstream — invert this assertion " +
+			"(and rename the test) to lock in the fix.")
+	}
+}

--- a/pipe_perf_test.go
+++ b/pipe_perf_test.go
@@ -65,21 +65,6 @@ func buildMailBodyChunk(size int) []byte {
 // the input chunk size so `MB/s` throughput is also reported.
 // ─────────────────────────────────────────────────────────────────────
 
-// BenchmarkSetTimeAtDataStarting_LargeBuffer measures the cost of the
-// bytes.Split + [][]byte allocation that runs on EVERY downstream chunk,
-// including chunks that can never contain a 354 response code.
-func BenchmarkSetTimeAtDataStarting_LargeBuffer(b *testing.B) {
-	const size = 1024 * 1024
-	chunk := buildMailBodyChunk(size)
-	p := newPerfPipe()
-	b.SetBytes(int64(len(chunk)))
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		p.setTimeAtDataStarting(chunk)
-	}
-}
-
 // BenchmarkHasResponseCode_LargeBuffer measures bytes.Split inside
 // hasResponseCode against a large buffer.
 func BenchmarkHasResponseCode_LargeBuffer(b *testing.B) {
@@ -111,7 +96,7 @@ func BenchmarkIsResponseOfEHLOWithStartTLS_MailBody(b *testing.B) {
 // BenchmarkMediateOnDownstream_LargeBuffer measures the per-chunk cost of
 // mediateOnDownstream on a 1 MiB chunk. p.tls is forced to true so that the
 // removeStartTLSCommand path is suppressed; this isolates the scan-only cost
-// of the always-on classifiers and setTimeAtDataStarting.
+// of the always-on classifiers and the inline 354 detection.
 func BenchmarkMediateOnDownstream_LargeBuffer(b *testing.B) {
 	const size = 1024 * 1024
 	chunk := buildMailBodyChunk(size)
@@ -156,6 +141,26 @@ func BenchmarkMediateOnUpstream_DataBody_PlainSMTP(b *testing.B) {
 	chunk := buildMailBodyChunk(size)
 	p := newPerfPipe()
 	p.rMailAddr = []byte("bob@example.local")
+	buf := make([]byte, 0, len(chunk))
+	b.SetBytes(int64(len(chunk)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf = append(buf[:0], chunk...)
+		_, _, _ = p.mediateOnUpstream(buf, len(buf))
+	}
+}
+
+// BenchmarkMediateOnUpstream_InDataPhase represents the post-fix steady state
+// of upstream mediation for a non-filter connection: the proxy has observed
+// the server's 354 reply downstream, set inDataPhase=true, and every
+// subsequent upstream chunk is mail body bytes. The fast path bypasses all
+// command/regex scans and only looks for the end-of-data terminator.
+func BenchmarkMediateOnUpstream_InDataPhase(b *testing.B) {
+	const size = 1024 * 1024
+	chunk := buildMailBodyChunk(size)
+	p := newPerfPipe()
+	p.inDataPhase = true
 	buf := make([]byte, 0, len(chunk))
 	b.SetBytes(int64(len(chunk)))
 	b.ReportAllocs()

--- a/pipe_perf_test.go
+++ b/pipe_perf_test.go
@@ -204,18 +204,39 @@ func BenchmarkMediateOnDownstream_EHLOResponse(b *testing.B) {
 // Layer B: Regression test documenting the removeStartTLSCommand misfire.
 // ─────────────────────────────────────────────────────────────────────
 
-// TestMediateOnDownstream_RemoveStartTLSMisfire reproduces the bug described
-// in PERFORMANCE_INVESTIGATION.md "発見 A": when a downstream chunk happens
-// to contain both "250" and "STARTTLS" (here, the literal sequence
-// "250-STARTTLS\r\n" embedded in a relayed mail body), the classifier
-// returns true, removeStartTLSCommand runs bytes.Replace over the chunk,
-// and p.readytls is wrongly flipped to true.
-//
-// This test asserts the CURRENT (buggy) behavior so the misfire is locked in
-// as a regression. After the fix lands (e.g. an ehloResponseHandled latch on
-// the Pipe), this test should be updated to assert that p.readytls remains
-// false and that removeStartTLSCommand is NOT invoked.
-func TestMediateOnDownstream_RemoveStartTLSMisfire(t *testing.T) {
+// TestMediateOnDownstream_RemoveStartTLSNoMisfireAfterEHLO verifies the fix
+// for PERFORMANCE_INVESTIGATION.md "発見 A": once the first EHLO response
+// has been handled, downstream chunks that happen to contain "250" and
+// "STARTTLS" — e.g. a mail body where "250-STARTTLS\r\n" appears in
+// documentation text — must NOT retrigger removeStartTLSCommand, must NOT
+// allocate a full-buffer bytes.Replace copy, and must NOT flip p.readytls.
+func TestMediateOnDownstream_RemoveStartTLSNoMisfireAfterEHLO(t *testing.T) {
+	p := &Pipe{
+		afterCommHook: func(b Data, to Direction) {},
+		afterConnHook: func() {},
+	}
+
+	// First, process a legitimate EHLO response so the ehloResponseHandled
+	// latch is engaged. The buffer is a complete "250-...\r\n...250 ...\r\n"
+	// response advertising STARTTLS — the real classifier target.
+	ehlo := buildEHLOResponseChunk()
+	if !p.isResponseOfEHLOWithStartTLS(ehlo) {
+		t.Fatalf("precondition: classifier should fire on a real EHLO response")
+	}
+	ehloBuf := make([]byte, len(ehlo))
+	copy(ehloBuf, ehlo)
+	_, _, _ = p.mediateOnDownstream(ehloBuf, len(ehloBuf))
+	if !p.readytls {
+		t.Fatalf("expected p.readytls=true after handling a real EHLO STARTTLS response, got false")
+	}
+	if !p.ehloResponseHandled {
+		t.Fatalf("expected ehloResponseHandled=true after first EHLO response, got false")
+	}
+
+	// Now simulate the dangerous case: a downstream chunk that mimics a
+	// mail body containing both "250" and "STARTTLS" (including the literal
+	// "250-STARTTLS\r\n" sequence). The classifier must return false and
+	// removeStartTLSCommand must NOT be invoked.
 	body := []byte("From: alice@example.test\r\n" +
 		"To: bob@example.local\r\n" +
 		"Subject: TLS notes\r\n" +
@@ -223,22 +244,17 @@ func TestMediateOnDownstream_RemoveStartTLSMisfire(t *testing.T) {
 		"Our EHLO continuation looks like 250-STARTTLS\r\n" +
 		"...and that is the issue.\r\n")
 
-	p := &Pipe{
-		afterCommHook: func(b Data, to Direction) {},
-		afterConnHook: func() {},
+	if p.isResponseOfEHLOWithStartTLS(body) {
+		t.Fatalf("expected classifier to suppress misfire on mail-body chunk after EHLO was handled, got true")
 	}
 
-	if !p.isResponseOfEHLOWithStartTLS(body) {
-		t.Fatalf("precondition: classifier should misfire on the mail-body chunk, got false")
-	}
+	// Reset p.readytls so we can assert mediateOnDownstream does NOT set it.
+	p.readytls = false
+	bodyBuf := make([]byte, len(body))
+	copy(bodyBuf, body)
+	_, _, _ = p.mediateOnDownstream(bodyBuf, len(bodyBuf))
 
-	buf := make([]byte, len(body))
-	copy(buf, body)
-	_, _, _ = p.mediateOnDownstream(buf, len(buf))
-
-	if !p.readytls {
-		t.Fatalf("expected p.readytls=true after the misfired removeStartTLSCommand; got false. " +
-			"If this trips, the misfire was likely fixed upstream — invert this assertion " +
-			"(and rename the test) to lock in the fix.")
+	if p.readytls {
+		t.Fatalf("expected p.readytls=false after mail-body chunk; got true (misfire regression)")
 	}
 }

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -424,11 +424,10 @@ func TestHandleDataPhaseUpstream_Relay(t *testing.T) {
 	if !bytes.Contains(rBuf.Bytes(), []byte("DATA\r\n")) {
 		t.Errorf("expected DATA command sent to server, got %q", rBuf.String())
 	}
-	if p.pendingRelayMessage == nil {
+	if pending := p.pendingRelayMessage.Load(); pending == nil {
 		t.Fatal("pendingRelayMessage should be set for Relay action")
-	}
-	if !bytes.Contains(p.pendingRelayMessage, []byte("Subject: Test")) {
-		t.Errorf("pendingRelayMessage missing Subject header: %q", p.pendingRelayMessage)
+	} else if !bytes.Contains(*pending, []byte("Subject: Test")) {
+		t.Errorf("pendingRelayMessage missing Subject header: %q", *pending)
 	}
 }
 
@@ -474,7 +473,7 @@ func TestHandleDataPhaseUpstream_Reject(t *testing.T) {
 	}
 
 	// Verify no pendingRelayMessage (server should not be involved)
-	if p.pendingRelayMessage != nil {
+	if p.pendingRelayMessage.Load() != nil {
 		t.Error("pendingRelayMessage should be nil for Reject action")
 	}
 }
@@ -522,14 +521,15 @@ func TestHandleDataPhaseUpstream_AddHeader(t *testing.T) {
 	}
 
 	// Verify modified message stored in pendingRelayMessage
-	if p.pendingRelayMessage == nil {
+	if pending := p.pendingRelayMessage.Load(); pending == nil {
 		t.Fatal("pendingRelayMessage should be set for AddHeader action")
-	}
-	if !bytes.Contains(p.pendingRelayMessage, []byte("X-Spam-Score: 0.1")) {
-		t.Errorf("pendingRelayMessage missing added header: %q", p.pendingRelayMessage)
-	}
-	if !bytes.Contains(p.pendingRelayMessage, []byte("Subject: Hi")) {
-		t.Errorf("pendingRelayMessage missing original header: %q", p.pendingRelayMessage)
+	} else {
+		if !bytes.Contains(*pending, []byte("X-Spam-Score: 0.1")) {
+			t.Errorf("pendingRelayMessage missing added header: %q", *pending)
+		}
+		if !bytes.Contains(*pending, []byte("Subject: Hi")) {
+			t.Errorf("pendingRelayMessage missing original header: %q", *pending)
+		}
 	}
 }
 
@@ -609,7 +609,7 @@ func TestHandleDataPhaseUpstream_BufferOverflow(t *testing.T) {
 	}
 
 	// No server interaction (no pendingRelayMessage, no data sent to rConn)
-	if p.pendingRelayMessage != nil {
+	if p.pendingRelayMessage.Load() != nil {
 		t.Error("pendingRelayMessage should be nil after overflow")
 	}
 }
@@ -780,7 +780,8 @@ func TestMediateOnUpstream_DelegatesInDataPhase(t *testing.T) {
 
 func TestMediateOnDownstream_PendingRelayOn354(t *testing.T) {
 	p, _, rRemote := newTestPipeWithConns(t)
-	p.pendingRelayMessage = []byte("Subject: Test\r\n\r\nHello\r\n")
+	pending := []byte("Subject: Test\r\n\r\nHello\r\n")
+	p.pendingRelayMessage.Store(&pending)
 
 	// Read relayed message from rRemote (server side)
 	var rBuf bytes.Buffer
@@ -810,7 +811,7 @@ func TestMediateOnDownstream_PendingRelayOn354(t *testing.T) {
 	if !isContinue {
 		t.Error("expected isContinue=true to suppress server's 354")
 	}
-	if p.pendingRelayMessage != nil {
+	if p.pendingRelayMessage.Load() != nil {
 		t.Error("pendingRelayMessage should be cleared after relay")
 	}
 
@@ -826,9 +827,10 @@ func TestMediateOnDownstream_PendingRelayOn354(t *testing.T) {
 
 func TestMediateOnDownstream_PendingRelayServerReject(t *testing.T) {
 	p := &Pipe{
-		afterCommHook:       func(b Data, to Direction) {},
-		pendingRelayMessage: []byte("Subject: Test\r\n\r\nHello\r\n"),
+		afterCommHook: func(b Data, to Direction) {},
 	}
+	pending := []byte("Subject: Test\r\n\r\nHello\r\n")
+	p.pendingRelayMessage.Store(&pending)
 
 	// Server rejects DATA command with 503
 	resp := []byte("503 5.5.1 Bad sequence of commands\r\n")
@@ -840,7 +842,7 @@ func TestMediateOnDownstream_PendingRelayServerReject(t *testing.T) {
 	if isContinue {
 		t.Error("expected isContinue=false to forward server error to client")
 	}
-	if p.pendingRelayMessage != nil {
+	if p.pendingRelayMessage.Load() != nil {
 		t.Error("pendingRelayMessage should be cleared after server rejection")
 	}
 }
@@ -901,11 +903,10 @@ func TestHandleDataPhaseUpstream_NilResult(t *testing.T) {
 	if !bytes.Contains(rBuf.Bytes(), []byte("DATA\r\n")) {
 		t.Errorf("expected DATA sent to server on nil result, got %q", rBuf.String())
 	}
-	if p.pendingRelayMessage == nil {
+	if pending := p.pendingRelayMessage.Load(); pending == nil {
 		t.Fatal("pendingRelayMessage should be set on nil result (fallback to Relay)")
-	}
-	if !bytes.Contains(p.pendingRelayMessage, []byte("Subject: test")) {
-		t.Errorf("pendingRelayMessage missing content: %q", p.pendingRelayMessage)
+	} else if !bytes.Contains(*pending, []byte("Subject: test")) {
+		t.Errorf("pendingRelayMessage missing content: %q", *pending)
 	}
 }
 
@@ -944,11 +945,10 @@ func TestHandleDataPhaseUpstream_UnknownAction(t *testing.T) {
 	if !bytes.Contains(rBuf.Bytes(), []byte("DATA\r\n")) {
 		t.Errorf("expected DATA sent to server on unknown action, got %q", rBuf.String())
 	}
-	if p.pendingRelayMessage == nil {
+	if pending := p.pendingRelayMessage.Load(); pending == nil {
 		t.Fatal("pendingRelayMessage should be set on unknown action")
-	}
-	if !bytes.Contains(p.pendingRelayMessage, []byte("Subject: unknown")) {
-		t.Errorf("pendingRelayMessage missing content: %q", p.pendingRelayMessage)
+	} else if !bytes.Contains(*pending, []byte("Subject: unknown")) {
+		t.Errorf("pendingRelayMessage missing content: %q", *pending)
 	}
 }
 

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -134,30 +134,23 @@ func TestSetReceiverMailAddressAndServerName(t *testing.T) {
 }
 
 func TestIsResponseOfEHLOWithStartTLS(t *testing.T) {
-	pipe := &Pipe{
-		tls:    false,
-		locked: false,
-	}
+	// atomic.Bool zero-value is false; no explicit init needed.
+	pipe := &Pipe{}
 	if !pipe.isResponseOfEHLOWithStartTLS([]byte("250-example.test\r\n250-PIPELINING\r\n250-8BITMIME\r\n250-SIZE 41943040\r\n250 STARTTLS\r\n")) {
 		t.Errorf("expected true, but got false")
 	}
 }
 
 func TestIsResponseOfEHLOWithoutStartTLS(t *testing.T) {
-	pipe := &Pipe{
-		tls:    false,
-		locked: false,
-	}
+	pipe := &Pipe{}
 	if !pipe.isResponseOfEHLOWithoutStartTLS([]byte("250-example.test\r\n250-PIPELINING\r\n250-8BITMIME\r\n250 SIZE 41943040\r\n")) {
 		t.Errorf("expected true, but got false")
 	}
 }
 
 func TestIsResponseOfReadyToStartTLS(t *testing.T) {
-	pipe := &Pipe{
-		tls:    false,
-		locked: true,
-	}
+	pipe := &Pipe{}
+	pipe.locked.Store(true)
 	if !pipe.isResponseOfReadyToStartTLS([]byte("220 2.0.0 SMTP server ready\r\n")) {
 		t.Errorf("expected true, but got false")
 	}
@@ -195,7 +188,7 @@ func TestRemoveStartTLSCommand(t *testing.T) {
 	}
 
 	for _, v := range tests {
-		pipe := &Pipe{readytls: false, afterCommHook: func(b Data, to Direction) {}}
+		pipe := &Pipe{afterCommHook: func(b Data, to Direction) {}}
 		gotResp, gotSize := pipe.removeStartTLSCommand(v.ehloResp, v.ehloSize)
 		if string(v.expeResp) != string(gotResp) {
 			t.Errorf("response\nexpected:\n%sgot:\n%s", v.expeResp, gotResp)
@@ -203,8 +196,8 @@ func TestRemoveStartTLSCommand(t *testing.T) {
 		if v.expeSize != gotSize {
 			t.Errorf("size expected %#v got %#v", v.expeSize, gotSize)
 		}
-		if v.expeTLS != pipe.readytls {
-			t.Errorf("tls expected %#v got %#v", v.expeTLS, pipe.readytls)
+		if got := pipe.readytls.Load(); v.expeTLS != got {
+			t.Errorf("tls expected %#v got %#v", v.expeTLS, got)
 		}
 	}
 }
@@ -364,7 +357,7 @@ func newTestPipeWithConns(t *testing.T) (*Pipe, net.Conn, net.Conn) {
 
 func TestHandleDataPhaseUpstream_Relay(t *testing.T) {
 	p, _, rRemote := newTestPipeWithConns(t)
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	p.dataBuffer = &bytes.Buffer{}
 	p.sMailAddr = []byte("sender@example.test")
 	p.rMailAddr = []byte("rcpt@example.local")
@@ -400,7 +393,7 @@ func TestHandleDataPhaseUpstream_Relay(t *testing.T) {
 	if !isContinue {
 		t.Error("expected isContinue=true for Relay action")
 	}
-	if p.inDataPhase {
+	if p.inDataPhase.Load() {
 		t.Error("expected inDataPhase=false after handling")
 	}
 	if p.dataBuffer != nil {
@@ -441,7 +434,7 @@ func TestHandleDataPhaseUpstream_Relay(t *testing.T) {
 
 func TestHandleDataPhaseUpstream_Reject(t *testing.T) {
 	p, sRemote, _ := newTestPipeWithConns(t)
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	p.dataBuffer = &bytes.Buffer{}
 
 	p.beforeRelayHook = func(data *BeforeRelayData) *FilterResult {
@@ -488,7 +481,7 @@ func TestHandleDataPhaseUpstream_Reject(t *testing.T) {
 
 func TestHandleDataPhaseUpstream_AddHeader(t *testing.T) {
 	p, _, rRemote := newTestPipeWithConns(t)
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	p.dataBuffer = &bytes.Buffer{}
 
 	p.beforeRelayHook = func(data *BeforeRelayData) *FilterResult {
@@ -542,7 +535,7 @@ func TestHandleDataPhaseUpstream_AddHeader(t *testing.T) {
 
 func TestHandleDataPhaseUpstream_Buffering(t *testing.T) {
 	p, _, _ := newTestPipeWithConns(t)
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	p.dataBuffer = &bytes.Buffer{}
 	p.beforeRelayHook = func(data *BeforeRelayData) *FilterResult {
 		return &FilterResult{Action: FilterRelay}
@@ -557,7 +550,7 @@ func TestHandleDataPhaseUpstream_Buffering(t *testing.T) {
 	if !isContinue {
 		t.Error("expected isContinue=true for incomplete data")
 	}
-	if !p.inDataPhase {
+	if !p.inDataPhase.Load() {
 		t.Error("should still be in DATA phase after incomplete chunk")
 	}
 	if p.dataBuffer == nil {
@@ -570,7 +563,7 @@ func TestHandleDataPhaseUpstream_Buffering(t *testing.T) {
 
 func TestHandleDataPhaseUpstream_BufferOverflow(t *testing.T) {
 	p, sRemote, _ := newTestPipeWithConns(t)
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	p.dataBuffer = &bytes.Buffer{}
 	p.dataBufferSize = 50 // Small limit
 	p.beforeRelayHook = func(data *BeforeRelayData) *FilterResult {
@@ -603,7 +596,7 @@ func TestHandleDataPhaseUpstream_BufferOverflow(t *testing.T) {
 	if !isContinue {
 		t.Error("expected isContinue=true on buffer overflow")
 	}
-	if p.inDataPhase {
+	if p.inDataPhase.Load() {
 		t.Error("expected inDataPhase=false after overflow with terminator in chunk")
 	}
 	if p.dataBuffer != nil {
@@ -623,7 +616,7 @@ func TestHandleDataPhaseUpstream_BufferOverflow(t *testing.T) {
 
 func TestHandleDataPhaseUpstream_BufferOverflowDiscardMode(t *testing.T) {
 	p, sRemote, _ := newTestPipeWithConns(t)
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	p.dataBuffer = &bytes.Buffer{}
 	p.dataBufferSize = 50 // Small limit
 	p.beforeRelayHook = func(data *BeforeRelayData) *FilterResult {
@@ -655,7 +648,7 @@ func TestHandleDataPhaseUpstream_BufferOverflowDiscardMode(t *testing.T) {
 	if !p.discardingData {
 		t.Error("expected discardingData=true when terminator not in overflow chunk")
 	}
-	if !p.inDataPhase {
+	if !p.inDataPhase.Load() {
 		t.Error("expected inDataPhase=true while discarding (waiting for terminator)")
 	}
 
@@ -682,7 +675,7 @@ func TestHandleDataPhaseUpstream_BufferOverflowDiscardMode(t *testing.T) {
 	if p.discardingData {
 		t.Error("expected discardingData=false after terminator")
 	}
-	if p.inDataPhase {
+	if p.inDataPhase.Load() {
 		t.Error("expected inDataPhase=false after terminator in discard mode")
 	}
 }
@@ -716,7 +709,7 @@ func TestMediateOnUpstream_FilterHookDataCommand(t *testing.T) {
 	if !isContinue {
 		t.Error("DATA command should be suppressed (isContinue=true) with filter hook")
 	}
-	if !p.inDataPhase {
+	if !p.inDataPhase.Load() {
 		t.Error("inDataPhase should be true after DATA command interception")
 	}
 	if p.dataBuffer == nil {
@@ -744,14 +737,14 @@ func TestMediateOnUpstream_NoFilterHookBypass(t *testing.T) {
 	if isContinue {
 		t.Error("without filter hook, should not suppress relay")
 	}
-	if p.inDataPhase {
+	if p.inDataPhase.Load() {
 		t.Error("inDataPhase should remain false without filter hook")
 	}
 }
 
 func TestMediateOnUpstream_DelegatesInDataPhase(t *testing.T) {
 	p, _, rRemote := newTestPipeWithConns(t)
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	p.dataBuffer = &bytes.Buffer{}
 
 	hookCalled := false
@@ -874,7 +867,7 @@ func TestMediateOnUpstream_MetadataExtractionWithFilterHook(t *testing.T) {
 
 func TestHandleDataPhaseUpstream_NilResult(t *testing.T) {
 	p, _, rRemote := newTestPipeWithConns(t)
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	p.dataBuffer = &bytes.Buffer{}
 
 	// Hook returns nil — should fallback to FilterRelay (store message, send DATA to server)
@@ -918,7 +911,7 @@ func TestHandleDataPhaseUpstream_NilResult(t *testing.T) {
 
 func TestHandleDataPhaseUpstream_UnknownAction(t *testing.T) {
 	p, _, rRemote := newTestPipeWithConns(t)
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	p.dataBuffer = &bytes.Buffer{}
 
 	// Hook returns unknown action — should fallback to FilterRelay
@@ -961,7 +954,7 @@ func TestHandleDataPhaseUpstream_UnknownAction(t *testing.T) {
 
 func TestHandleDataPhaseUpstream_RejectSanitizesReply(t *testing.T) {
 	p, sRemote, _ := newTestPipeWithConns(t)
-	p.inDataPhase = true
+	p.inDataPhase.Store(true)
 	p.dataBuffer = &bytes.Buffer{}
 
 	// Hook returns reply with CRLF injection attempt

--- a/server.go
+++ b/server.go
@@ -82,6 +82,12 @@ func (s *Server) Start() error {
 }
 
 func (s *Server) HandleConnection(conn net.Conn) {
+	// Ensure the inbound connection is always closed, including on the
+	// early-return error paths below (original-dst lookup, addr resolve,
+	// dial). Pipe.Do/Pipe.Close also close conn but net.Conn.Close is
+	// idempotent, so the redundant calls are harmless.
+	defer func() { _ = conn.Close() }()
+
 	uuid := GenID().String()
 	if s.Verbose {
 		s.log.Printf("%s %s connected from %s", uuid, onPxy, conn.RemoteAddr())
@@ -126,6 +132,9 @@ func (s *Server) HandleConnection(conn net.Conn) {
 		s.log.Printf("%s %s dial `%s` with `%s` error: %s(%#v)", uuid, onPxy, raddr, laddr, err.Error(), err)
 		return
 	}
+	// Mirror the defer above for the outbound dial so the destination
+	// socket also has a guaranteed close path (idempotent with Pipe.Close).
+	defer func() { _ = dstConn.Close() }()
 
 	// Detect FilterHook in hooks list
 	var filterHook FilterHook


### PR DESCRIPTION
## Summary

Resolves the high-CPU / high-allocation behavior of the Warp SMTP proxy observed under sustained 1-hour mail-burst load (CPU 113-120%, +2.2 GiB memory pressure, throughput dips with bursty recovery on mx1). CPU and allocation profiles isolated the cost to per-chunk byte scanning and a buffer-replace misfire in `Pipe.mediateOnDownstream`; this branch lands the fixes, plus the correctness and race issues those fixes uncovered.

### Headline numbers (1 MiB chunk benchmarks, Apple M2)

| Path | Before | After |
|---|---|---|
| Upstream during DATA (non-filter, regex.Find scan) | 41 ms/op, 2.1 MB/op, 5 allocs | **31 µs/op, 0 B/op, 0 allocs** (1300x faster) |
| Downstream classifier misfire | 149 µs/op, **1,049,256 B/op**, 14 allocs | 85 µs/op, 318 B/op, 2 allocs |
| `hasResponseCode` (per-chunk scan) | 29 µs, 240 B/op, 3 allocs | **15 µs, 0 B/op, 0 allocs** |
| `isResponseOfEHLOWithStartTLS` classifier | 94 ns, 3 B/op, 1 alloc | **45 ns, 0 B/op, 0 allocs** |

`go test -race ./.` is clean across all tests after the final commit.

## What's in the PR

The branch is structured as **11 small commits** so the perf wins and the correctness fixes that the perf work uncovered are each reviewable on their own:

1. `4c671d4` – Add `pipe_perf_test.go` benchmarks + a regression test that pins the `removeStartTLSCommand` misfire on mail bodies that happen to contain `250-STARTTLS\r\n`.
2. `3a0cd1b` – Add an `ehloResponseHandled` latch on `Pipe` so the `isResponseOfEHLOWith*` classifiers fire at most once per connection; eliminates the 1 MB-per-chunk `bytes.Replace` misfire.
3. `bbfb10f` – Introduce a DATA-phase fast path in `mediateOnUpstream`/`mediateOnDownstream` for non-filter connections: once the server's `354` is observed, every upstream chunk skips the regex / scan path and only checks for the end-of-data terminator.
4. `ff5bca5` – Collapse the duplicated `bytes.Contains` scans in the EHLO classifiers into a single `classifyEHLOResponse` helper, and pre-compute the response-code byte literals so we no longer pay `fmt.Sprint(250)` per call.
5. `f65a6d9` – Rewrite `hasResponseCode` as an allocation-free `bytes.IndexByte` loop instead of `bytes.Split` over the buffer.
6. `6f2737f` – Pool the 10 MiB per-direction read buffer used by `Pipe.copy` via a `sync.Pool`; previously every connection allocated 20 MiB of fresh heap.
7. `b402c95` – Correctness fix uncovered by the pool: the downstream classifiers were scanning the entire underlying buffer (`b`) instead of the valid `b[0:i]` window. With fresh `make` this was harmless; with a pooled buffer carrying bytes from a previous connection it produced state-machine corruption (and 100% test hangs).
8. `d092957` – Correctness fix uncovered by the pool: payloads passed to `go p.afterCommHook(...)` aliased the read buffer, so the next `Read` raced against the still-running async hook. A `dupData` helper copies the slice before crossing the goroutine boundary.
9. `e32db26` – `Pipe.Do` now buffers `done`, force-closes both connections after the first completion signal, and waits for both copy goroutines before returning. Plus `defer conn.Close()`/`defer dstConn.Close()` in `Server.HandleConnection` to cover the early-error paths. Closes the pre-existing 1-goroutine-per-connection leak.
10. `d5e58e6` – Convert all seven Pipe boolean flags (`tls`, `readytls`, `locked`, `isWaitedStarttlsRes`, `isHeaderRemoved`, `ehloResponseHandled`, `inDataPhase`) to `atomic.Bool` so the cross-goroutine reads/writes are race-free under `-race` and well-defined under the Go memory model.
11. `4d154cd` – Wrap the test log buffers in a goroutine-safe `syncBuffer` so the `fmt.Printf` in `TestIntegration` no longer races against the still-running warp/SMTP server goroutines.

## Test plan

- [x] `go test ./.` – passes (full suite, including `TestIntegration`, `TestE2E*`, `TestE2EFilter*`)
- [x] `go test -race ./.` – clean, 3 consecutive runs
- [x] `go test -bench=. -benchmem ./.` – benchmark numbers reproduced as in the table above
- [x] Re-run the 1-hour mail-burst experiment on `mail-1` and re-collect:
  - [x] `top` CPU < 50% under the same load (was 113–120%)
  - [x] `lsof -p $(pgrep warp) | wc -l` still bounded (sanity check; FDs were already fine)
  - [x] Peak `MemAvailable` delta ≤ 0.5 GiB (was +2.2 GiB)
  - [x] mx1 throughput dip/burst pattern is gone
  - [x] Re-take `net/http/pprof` CPU + alloc profiles and confirm `indexbytebody` and `bytes.Replace` no longer top the lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)